### PR TITLE
Replace placeholder content with Prosper Spot branding

### DIFF
--- a/assets/css/lindy-uikit.css
+++ b/assets/css/lindy-uikit.css
@@ -41,7 +41,7 @@ button {
 .scroll-top {
   width: 45px;
   height: 45px;
-  background: #2F80ED;
+  background: #6E44FF;
   display: none;
   justify-content: center;
   align-items: center;
@@ -58,7 +58,7 @@ button {
 
 .scroll-top:hover {
   color: #ffffff;
-  background: rgba(47, 128, 237, 0.8);
+  background: rgba(110, 68, 255, 0.8);
 }
 
 /* ============================= 
@@ -137,7 +137,7 @@ button {
   height: 100%;
   border-style: solid;
   /* Spinner Color */
-  border-color: #2F80ED #2F80ED #E9E9E9;
+  border-color: #6E44FF #6E44FF #E9E9E9;
   border-radius: 50%;
   border-width: 6px;
 }
@@ -308,7 +308,7 @@ p {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  background: #2F80ED;
+  background: #6E44FF;
   color: #ffffff;
   border: 1px solid transparent;
   position: relative;
@@ -347,12 +347,12 @@ p {
 
 .button.border-button {
   background: transparent;
-  color: #2F80ED;
-  border-color: #2F80ED;
+  color: #6E44FF;
+  border-color: #6E44FF;
 }
 
 .button.border-button::before {
-  background: rgba(47, 128, 237, 0.16);
+  background: rgba(110, 68, 255, 0.16);
 }
 
 .button-lg {
@@ -513,8 +513,8 @@ p {
 }
 
 .header.header-6 .navbar-nav .nav-item a:hover, .header.header-6 .navbar-nav .nav-item a.active {
-  color: #2F80ED;
-  border-color: #2F80ED;
+  color: #6E44FF;
+  border-color: #6E44FF;
 }
 
 .header.header-6 .navbar-nav .nav-item:hover .sub-menu {
@@ -581,7 +581,7 @@ p {
 
 .header.header-6 .navbar-nav .nav-item .sub-menu li a.active, .header.header-6 .navbar-nav .nav-item .sub-menu li a:hover {
   padding-left: 25px;
-  color: #2F80ED;
+  color: #6E44FF;
 }
 
 .header.header-6 .navbar-nav .sub-nav-toggler {
@@ -805,12 +805,12 @@ p {
 }
 
 .feature-style-5 .single-feature:hover {
-  border-color: #2F80ED;
-  box-shadow: 0px 8px 25px rgba(47, 128, 237, 0.35);
+  border-color: #6E44FF;
+  box-shadow: 0px 8px 25px rgba(110, 68, 255, 0.35);
 }
 
 .feature-style-5 .single-feature .icon {
-  color: #2F80ED;
+  color: #6E44FF;
   font-size: 45px;
   display: flex;
   justify-content: center;
@@ -883,7 +883,7 @@ p {
 }
 
 .pricing-style-4 .pricing-active-wrapper .tns-controls button:hover {
-  background: #2F80ED;
+  background: #6E44FF;
   color: #ffffff;
 }
 
@@ -947,7 +947,7 @@ p {
 
 .pricing-style-4 .pricing-active .single-pricing h3 {
   margin-bottom: 18px;
-  color: #2F80ED;
+  color: #6E44FF;
 }
 
 .pricing-style-4 .pricing-active .single-pricing ul {
@@ -1043,7 +1043,7 @@ p {
 
 .contact-style-3 .contact-form-wrapper form .single-input textarea:focus,
 .contact-style-3 .contact-form-wrapper form .single-input input:focus {
-  border-color: #2F80ED;
+  border-color: #6E44FF;
 }
 
 .contact-style-3 .contact-form-wrapper form .single-input input {
@@ -1106,7 +1106,7 @@ p {
 }
 
 .contact-style-3 .left-wrapper .single-item:hover {
-  box-shadow: 0px 5px 25px rgba(47, 128, 237, 0.3);
+  box-shadow: 0px 5px 25px rgba(110, 68, 255, 0.3);
 }
 
 .contact-style-3 .left-wrapper .single-item .icon {
@@ -1114,7 +1114,7 @@ p {
   width: 100%;
   height: 54px;
   border-radius: 50%;
-  background: #2F80ED;
+  background: #6E44FF;
   color: #ffffff;
   margin-right: 20px;
   display: flex;
@@ -1148,7 +1148,7 @@ p {
 }
 
 .footer-style-4 .widget-wrapper .footer-widget .socials li a {
-  background: rgba(47, 128, 237, 0.4);
+  background: rgba(110, 68, 255, 0.4);
   margin: 0;
   margin-right: 10px;
   width: 44px;
@@ -1157,7 +1157,7 @@ p {
 }
 
 .footer-style-4 .widget-wrapper .footer-widget .socials li a:hover {
-  background: #2F80ED;
+  background: #6E44FF;
 }
 
 .footer-style-4 .widget-wrapper .footer-widget h6 {
@@ -1174,7 +1174,7 @@ p {
 }
 
 .footer-style-4 .widget-wrapper .footer-widget .links li a:hover {
-  color: #2F80ED;
+  color: #6E44FF;
 }
 
 .footer-style-4 .widget-wrapper .footer-widget .download-app li a {
@@ -1225,7 +1225,7 @@ p {
 }
 
 .footer-style-4 .copyright-wrapper p a:hover {
-  color: #2F80ED;
+  color: #6E44FF;
 }
 
 .footer-style-4.footer-dark {
@@ -1245,7 +1245,7 @@ p {
 }
 
 .footer-style-4.footer-dark .widget-wrapper .footer-widget .socials li a:hover {
-  background: #2F80ED;
+  background: #6E44FF;
 }
 
 .footer-style-4.footer-dark .widget-wrapper .footer-widget .links li a {
@@ -1253,7 +1253,7 @@ p {
 }
 
 .footer-style-4.footer-dark .widget-wrapper .footer-widget .links li a:hover {
-  color: #2F80ED;
+  color: #6E44FF;
 }
 
 .footer-style-4.footer-dark .copyright-wrapper p {
@@ -1279,7 +1279,7 @@ p {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: #2F80ED;
+  background: #6E44FF;
   color: #ffffff;
   display: flex;
   justify-content: center;

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <title>Nova - Bootstrap 5 Template</title>
-    <meta name="description" content="" />
+    <title>Prosper Spot - Real AI Tools</title>
+    <meta name="description" content="Prosper Spot builds real AI tools for creators." />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Place favicon.ico in the root directory -->
 
@@ -53,9 +53,7 @@
             <div class="row align-items-center">
               <div class="col-lg-12">
                 <nav class="navbar navbar-expand-lg">
-                  <a class="navbar-brand" href="index.html">
-                    <img src="assets/img/logo/logo.svg" alt="Logo" />
-                  </a>
+                  <a class="navbar-brand" href="index.html">Prosper Spot</a>
                   <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent6" aria-controls="navbarSupportedContent6" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="toggler-icon"></span>
                     <span class="toggler-icon"></span>
@@ -68,7 +66,7 @@
                         <a class="page-scroll active" href="#home">Home</a>
                       </li>
                       <li class="nav-item">
-                        <a class="page-scroll" href="#feature">Feature</a>
+                        <a class="page-scroll" href="#services">Services</a>
                       </li>
                       <li class="nav-item">
                         <a class="page-scroll" href="#about">About</a>
@@ -106,9 +104,9 @@
           <div class="row">
             <div class="col-lg-6">
               <div class="hero-content-wrapper">
-                <h2 class="mb-30 wow fadeInUp" data-wow-delay=".2s">You're Using Free Lite Version</h2>
-                <p class="mb-30 wow fadeInUp" data-wow-delay=".4s">Please purchase full version of the template to get all sections and permission to use with commercial projects.</p>
-                <a href="#0" class="button button-lg radius-50 wow fadeInUp" data-wow-delay=".6s">Get Started <i class="lni lni-chevron-right"></i> </a>
+                <h2 class="mb-30 wow fadeInUp" data-wow-delay=".2s">Real AI Tools. Zero Gimmicks.</h2>
+                <p class="mb-30 wow fadeInUp" data-wow-delay=".4s">Custom agents, story pipelines, and LoRA training. Built for creators, not corporations.</p>
+                <a href="#contact" class="button button-lg radius-50 wow fadeInUp" data-wow-delay=".6s">Build With Us</a>
               </div>
             </div>
             <div class="col-lg-6 align-self-end">
@@ -125,13 +123,13 @@
     <!-- ========================= hero-section-wrapper-6 end ========================= -->
 
     <!-- ========================= feature style-5 start ========================= -->
-    <section id="feature" class="feature-section feature-style-5">
+    <section id="services" class="feature-section feature-style-5">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col-xxl-5 col-xl-5 col-lg-7 col-md-8">
             <div class="section-title text-center mb-60">
               <h3 class="mb-15 wow fadeInUp" data-wow-delay=".2s">Specializing In</h3>
-              <p class="wow fadeInUp" data-wow-delay=".4s">Stop wasting time and money designing and managing a website that doesn’t get results. Happiness guaranteed!</p>
+              <p class="wow fadeInUp" data-wow-delay=".4s">From chatbots to self‑hosted stacks, we build AI tools that actually work.</p>
             </div>
           </div>
         </div>
@@ -140,84 +138,84 @@
           <div class="col-lg-4 col-md-6">
             <div class="single-feature wow fadeInUp" data-wow-delay=".2s">
               <div class="icon">
-                <i class="lni lni-vector"></i>
+                <i class="lni lni-comments"></i>
                 <svg width="110" height="72" viewBox="0 0 110 72" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M110 54.7589C110 85.0014 85.3757 66.2583 55 66.2583C24.6243 66.2583 0 85.0014 0 54.7589C0 24.5164 24.6243 0 55 0C85.3757 0 110 24.5164 110 54.7589Z" fill="#EBF4FF"/>
-                  </svg>                  
+                  </svg>
               </div>
               <div class="content">
-                <h5>Graphics Design</h5>
-                <p>Short description for the ones who look for something new.</p>
+                <h5>Custom AI Chatbots</h5>
+                <p>Build your own AI assistant, roleplay character, or productivity agent. Hosted locally or via API with OpenWebUI.</p>
               </div>
             </div>
           </div>
           <div class="col-lg-4 col-md-6">
             <div class="single-feature wow fadeInUp" data-wow-delay=".4s">
               <div class="icon">
-                <i class="lni lni-pallet"></i>
+                <i class="lni lni-book"></i>
                 <svg width="110" height="72" viewBox="0 0 110 72" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M110 54.7589C110 85.0014 85.3757 66.2583 55 66.2583C24.6243 66.2583 0 85.0014 0 54.7589C0 24.5164 24.6243 0 55 0C85.3757 0 110 24.5164 110 54.7589Z" fill="#EBF4FF"/>
-                  </svg> 
+                  </svg>
               </div>
               <div class="content">
-                <h5>Print Design</h5>
-                <p>Short description for the ones who look for something new.</p>
+                <h5>AI-Powered Book Generation</h5>
+                <p>Rapid story creation for Kindle or web publishing. Full automation from outline to final draft — human-readable, zero fluff.</p>
               </div>
             </div>
           </div>
           <div class="col-lg-4 col-md-6">
             <div class="single-feature wow fadeInUp" data-wow-delay=".6s">
               <div class="icon">
-                <i class="lni lni-stats-up"></i>
+                <i class="lni lni-network"></i>
                 <svg width="110" height="72" viewBox="0 0 110 72" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M110 54.7589C110 85.0014 85.3757 66.2583 55 66.2583C24.6243 66.2583 0 85.0014 0 54.7589C0 24.5164 24.6243 0 55 0C85.3757 0 110 24.5164 110 54.7589Z" fill="#EBF4FF"/>
-                  </svg> 
+                  </svg>
               </div>
               <div class="content">
-                <h5>Business Analysis</h5>
-                <p>Short description for the ones who look for something new.</p>
+                <h5>LoRA Training for Character Consistency</h5>
+                <p>Custom LoRAs trained from client datasets for consistent faces, bodies, or outfits. Works with ControlNet & IP Adapter.</p>
               </div>
             </div>
           </div>
           <div class="col-lg-4 col-md-6">
             <div class="single-feature wow fadeInUp" data-wow-delay=".2s">
               <div class="icon">
-                <i class="lni lni-code-alt"></i>
+                <i class="lni lni-target"></i>
                 <svg width="110" height="72" viewBox="0 0 110 72" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M110 54.7589C110 85.0014 85.3757 66.2583 55 66.2583C24.6243 66.2583 0 85.0014 0 54.7589C0 24.5164 24.6243 0 55 0C85.3757 0 110 24.5164 110 54.7589Z" fill="#EBF4FF"/>
-                  </svg> 
+                  </svg>
               </div>
               <div class="content">
-                <h5>Web Development</h5>
-                <p>Short description for the ones who look for something new.</p>
+                <h5>Prompt Engineering & Tuning</h5>
+                <p>No more trial-and-error. Get image and text prompts that actually deliver results. Tailored for your model + use case.</p>
               </div>
             </div>
           </div>
           <div class="col-lg-4 col-md-6">
             <div class="single-feature wow fadeInUp" data-wow-delay=".4s">
               <div class="icon">
-                <i class="lni lni-lock"></i>
+                <i class="lni lni-cog"></i>
                 <svg width="110" height="72" viewBox="0 0 110 72" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M110 54.7589C110 85.0014 85.3757 66.2583 55 66.2583C24.6243 66.2583 0 85.0014 0 54.7589C0 24.5164 24.6243 0 55 0C85.3757 0 110 24.5164 110 54.7589Z" fill="#EBF4FF"/>
-                  </svg> 
+                  </svg>
               </div>
               <div class="content">
-                <h5>Best Security</h5>
-                <p>Short description for the ones who look for something new.</p>
+                <h5>AI Automation & Terminal Agents</h5>
+                <p>Bash shell, API, cron, you name it. AI agents with actual execution capabilities, not just simulated planning.</p>
               </div>
             </div>
           </div>
           <div class="col-lg-4 col-md-6">
             <div class="single-feature wow fadeInUp" data-wow-delay=".6s">
               <div class="icon">
-                <i class="lni lni-code"></i>
+                <i class="lni lni-database"></i>
                 <svg width="110" height="72" viewBox="0 0 110 72" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M110 54.7589C110 85.0014 85.3757 66.2583 55 66.2583C24.6243 66.2583 0 85.0014 0 54.7589C0 24.5164 24.6243 0 55 0C85.3757 0 110 24.5164 110 54.7589Z" fill="#EBF4FF"/>
-                  </svg> 
+                  </svg>
               </div>
               <div class="content">
-                <h5>Web Design</h5>
-                <p>Short description for the ones who look for something new.</p>
+                <h5>Self-Hosted AI Deployment</h5>
+                <p>Skip the cloud. We build local Docker stacks with Stable Diffusion, LLMs, and web UIs — full control, zero token hell.</p>
               </div>
             </div>
           </div>
@@ -234,24 +232,24 @@
           <div class="col-xl-5 col-lg-6">
             <div class="about-content-wrapper">
               <div class="section-title mb-30">
-                <h3 class="mb-25 wow fadeInUp" data-wow-delay=".2s">The future of designing starts here</h3>
-                <p class="wow fadeInUp" data-wow-delay=".3s">Stop wasting time and money designing and managing a website that doesn’t get results. Happiness guaranteed,</p>
+                <h3 class="mb-25 wow fadeInUp" data-wow-delay=".2s">AI-First Tools, Human Results</h3>
+                <p class="wow fadeInUp" data-wow-delay=".3s">Everything we build is meant to save you time and give you control — not lock you into token pricing, bad UX, or endless SaaS fees.</p>
               </div>
               <ul>
                 <li class="wow fadeInUp" data-wow-delay=".35s">
                   <i class="lni lni-checkmark-circle"></i>
-                  Stop wasting time and money designing and managing a website that doesn’t get results.
+                  Custom AI agents tailored to your workflow.
                 </li>
                 <li class="wow fadeInUp" data-wow-delay=".4s">
                   <i class="lni lni-checkmark-circle"></i>
-                  Stop wasting time and money designing and managing.
+                  End-to-end automation for writing, images, and code.
                 </li>
                 <li class="wow fadeInUp" data-wow-delay=".45s">
                   <i class="lni lni-checkmark-circle"></i>
-                  Stop wasting time and money designing and managing a website that doesn’t get results.
+                  Self-hosted deployments for full data control.
                 </li>
               </ul>
-              <a href="#0" class="button button-lg radius-10 wow fadeInUp" data-wow-delay=".5s">Learn More</a>
+              <a href="#services" class="button button-lg radius-10 wow fadeInUp" data-wow-delay=".5s">See What We Build</a>
             </div>
           </div>
           <div class="col-xl-7 col-lg-6">
@@ -270,8 +268,8 @@
         <div class="row align-items-center">
           <div class="col-xl-5 col-lg-6">
             <div class="section-title mb-60">
-              <h3 class="mb-15 wow fadeInUp" data-wow-delay=".2s">Pricing Plan</h3>
-              <p class="wow fadeInUp" data-wow-delay=".4s">Stop wasting time and money designing and managing a website that doesn’t get results. Happiness guaranteed!Stop wasting time and money designing and managing a website that doesn’t get results. Happiness guaranteed!</p>
+              <h3 class="mb-15 wow fadeInUp" data-wow-delay=".2s">Pricing</h3>
+              <p class="wow fadeInUp" data-wow-delay=".4s">Straightforward packages for your next AI project.</p>
             </div>
           </div>
           <div class="col-xl-7 col-lg-6">
@@ -279,47 +277,44 @@
               <div class="pricing-active">
                 <div class="single-pricing-wrapper">
                   <div class="single-pricing">
-                    <h6>Basic Design</h6>
-                    <h4>Web Design</h4>
-                    <h3>$ 29.00</h3>
+                    <h6>Basic Agent Build</h6>
+                    <h3>$49.00</h3>
                     <ul>
-                      <li>Carefully crafted components</li>
-                      <li>Amazing page examples</li>
-                      <li>Super friendly support team</li>
-                      <li>Awesome Support</li>
+                      <li>Local or API chatbot (OpenWebUI or ChatGPT)</li>
+                      <li>Persona tuning</li>
+                      <li>Prompt memory included</li>
+                      <li>3-day turnaround</li>
                     </ul>
-                    <a href="#0" class="button radius-30">Get Started</a>
+                    <a href="#contact" class="button radius-30">Get Started</a>
                   </div>
                 </div>
                 <div class="single-pricing-wrapper">
                   <div class="single-pricing">
-                    <h6>Standard Design</h6>
-                    <h4>Web Development</h4>
-                    <h3>$ 89.00</h3>
+                    <h6>Full Book Generation</h6>
+                    <h3>$129.00</h3>
                     <ul>
-                      <li>Carefully crafted components</li>
-                      <li>Amazing page examples</li>
-                      <li>Super friendly support team</li>
-                      <li>Awesome Support</li>
+                      <li>AI-drafted + revised novel or novella</li>
+                      <li>Based on outline or keywords</li>
+                      <li>Includes editing pass</li>
+                      <li>Delivered in .docx and .pdf</li>
                     </ul>
-                    <a href="#0" class="button radius-30">Get Started</a>
+                    <a href="#contact" class="button radius-30">Get Started</a>
                   </div>
                 </div>
                 <div class="single-pricing-wrapper">
                   <div class="single-pricing">
-                    <h6>Pro Design</h6>
-                    <h4>Design & Develop</h4>
-                    <h3>$ 199.00</h3>
+                    <h6>Custom LoRA Training</h6>
+                    <h3>$99.00</h3>
                     <ul>
-                      <li>Carefully crafted components</li>
-                      <li>Amazing page examples</li>
-                      <li>Super friendly support team</li>
-                      <li>Awesome Support</li>
+                      <li>15–30 images</li>
+                      <li>Full training + weight file</li>
+                      <li>SDXL or 1.5</li>
+                      <li>Works with ControlNet/IP-Adapter</li>
                     </ul>
-                    <a href="#0" class="button radius-30">Get Started</a>
+                    <a href="#contact" class="button radius-30">Get Started</a>
                   </div>
                 </div>
-                
+
               </div>
             </div>
           </div>
@@ -335,7 +330,7 @@
           <div class="col-xxl-5 col-xl-5 col-lg-7 col-md-10">
             <div class="section-title text-center mb-50">
               <h3 class="mb-15">Get in touch</h3>
-              <p>Stop wasting time and money designing and managing a website that doesn’t get results. Happiness guaranteed!</p>
+              <p>Tell us about your project and we'll get back within a day.</p>
             </div>
           </div>
         </div>
@@ -358,13 +353,13 @@
                   </div>
                   <div class="col-md-6">
                     <div class="single-input">
-                      <input type="text" id="number" name="number" class="form-input" placeholder="Number">
+                      <input type="text" id="phone" name="phone" class="form-input" placeholder="Phone">
                       <i class="lni lni-phone"></i>
                     </div>
                   </div>
                   <div class="col-md-6">
                     <div class="single-input">
-                      <input type="text" id="subject" name="subject" class="form-input" placeholder="Subject">
+                      <input type="text" id="project" name="project" class="form-input" placeholder="Project">
                       <i class="lni lni-text-format"></i>
                     </div>
                   </div>
@@ -394,8 +389,7 @@
                       <i class="lni lni-phone"></i>
                     </div>
                     <div class="text">
-                      <p>0045939863784</p>
-                      <p>+004389478327</p>
+                      <p>+1-614-653-7762</p>
                     </div>
                   </div>
                 </div>
@@ -405,8 +399,8 @@
                       <i class="lni lni-envelope"></i>
                     </div>
                     <div class="text">
-                      <p>yourmail@gmail.com</p>
-                      <p>admin@yourwebsite.com</p>
+                      <p>ben@prosperspot.com</p>
+                      <p>admin@prosperspot.com</p>
                     </div>
                   </div>
                 </div>
@@ -416,7 +410,7 @@
                       <i class="lni lni-map-marker"></i>
                     </div>
                     <div class="text">
-                      <p>John's House, 13/5 Road, Sidny United State Of America</p>
+                      <p>Based on the open sea, powered by local compute</p>
                     </div>
                   </div>
                 </div>
@@ -451,26 +445,24 @@
             <div class="col-xl-3 col-lg-4 col-md-6">
               <div class="footer-widget wow fadeInUp" data-wow-delay=".2s">
                 <div class="logo">
-                  <a href="#0"> <img src="assets/img/logo/logo.svg" alt=""> </a>
+                  <a href="#0">Prosper Spot</a>
                 </div>
-                <p class="desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Facilisis nulla placerat amet amet congue.</p>
+                <p class="desc">Prosper Spot builds open, creator-first AI solutions.</p>
                 <ul class="socials">
-                  <li> <a href="#0"> <i class="lni lni-facebook-filled"></i> </a> </li>
                   <li> <a href="#0"> <i class="lni lni-twitter-filled"></i> </a> </li>
-                  <li> <a href="#0"> <i class="lni lni-instagram-filled"></i> </a> </li>
-                  <li> <a href="#0"> <i class="lni lni-linkedin-original"></i> </a> </li>
+                  <li> <a href="#0"> <i class="lni lni-telegram"></i> </a> </li>
+                  <li> <a href="#0"> <i class="lni lni-github-original"></i> </a> </li>
                 </ul>
               </div>
             </div>
             <div class="col-xl-2 offset-xl-1 col-lg-2 col-md-6 col-sm-6">
               <div class="footer-widget wow fadeInUp" data-wow-delay=".3s">
-                <h6>Quick Link</h6>
+                <h6>Quick Links</h6>
                 <ul class="links">
-                  <li> <a href="#0">Home</a> </li>
-                  <li> <a href="#0">About</a> </li>
-                  <li> <a href="#0">Service</a> </li>
-                  <li> <a href="#0">Testimonial</a> </li>
-                  <li> <a href="#0">Contact</a> </li>
+                  <li> <a href="#home">Home</a> </li>
+                  <li> <a href="#services">Services</a> </li>
+                  <li> <a href="#pricing">Pricing</a> </li>
+                  <li> <a href="#contact">Contact</a> </li>
                 </ul>
               </div>
             </div>
@@ -478,10 +470,10 @@
               <div class="footer-widget wow fadeInUp" data-wow-delay=".4s">
                 <h6>Services</h6>
                 <ul class="links">
-                  <li> <a href="#0">Web Design</a> </li>
-                  <li> <a href="#0">Web Development</a> </li>
-                  <li> <a href="#0">Seo Optimization</a> </li>
-                  <li> <a href="#0">Blog Writing</a> </li>
+                  <li> <a href="#services">Chatbots</a> </li>
+                  <li> <a href="#services">Book Generation</a> </li>
+                  <li> <a href="#services">LoRA Training</a> </li>
+                  <li> <a href="#services">Prompt Engineering</a> </li>
                 </ul>
               </div>
             </div>
@@ -507,7 +499,7 @@
           </div>
         </div>
         <div class="copyright-wrapper wow fadeInUp" data-wow-delay=".2s">
-          <p>Design and Developed by <a href="https://uideck.com" rel="nofollow" target="_blank">UIdeck</a> Built-with <a href="https://uideck.com" rel="nofollow" target="_blank">Lindy UI Kit</a></p>
+          <p>Built by Prosper Spot powered by <a href="https://uideck.com" rel="nofollow" target="_blank">UIDeck</a>.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Rebrand site to Prosper Spot with new hero copy, services, pricing, contact info and footer links.
- Swap template accents for purple and wire up call-to-action links.

## Testing
- `npx -y htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_688f8473bb44832691da0dda2f5f25f3