### PR TITLE
Replace JavaScript alerts with auto-dismissing UI messages

### DIFF
--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,6 +1,18 @@
 document.addEventListener("DOMContentLoaded", function () {
   const form = document.getElementById("contact-form");
+  const messageContainer = document.getElementById("form-message");
+  let messageTimeout;
   if (!form) return;
+
+  function showMessage(text, type = "success") {
+    if (!messageContainer) return;
+    messageContainer.textContent = text;
+    messageContainer.className = `alert alert-${type} mt-3`;
+    if (messageTimeout) clearTimeout(messageTimeout);
+    messageTimeout = setTimeout(() => {
+      messageContainer.classList.add("d-none");
+    }, 3000);
+  }
 
   form.addEventListener("submit", async function (e) {
     e.preventDefault();
@@ -15,13 +27,13 @@ document.addEventListener("DOMContentLoaded", function () {
         body: formData,
       });
       if (response.ok) {
-        alert("Thanks for contacting us!");
+        showMessage("Thanks for contacting us!", "success");
         form.reset();
       } else {
-        alert("Oops! There was a problem submitting your form.");
+        showMessage("Oops! There was a problem submitting your form.", "danger");
       }
     } catch (error) {
-      alert("Oops! There was a problem submitting your form.");
+      showMessage("Oops! There was a problem submitting your form.", "danger");
     }
   });
 });

--- a/index.html
+++ b/index.html
@@ -376,6 +376,7 @@
                   </div>
                 </div>
               </form>
+              <div id="form-message" class="alert d-none mt-3" role="alert"></div>
             </div>
 
           </div>


### PR DESCRIPTION
## Summary
- add hidden alert container near contact form to display feedback messages
- replace JS `alert` calls with function that shows Bootstrap alerts and hides them after 3 seconds

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688fa3f19da48326ad2a5bf721b28aaf