### PR TITLE
Add subscription plans to pricing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,57 +251,77 @@
     <!-- ========================= pricing style-4 start ========================= -->
     <section id="pricing" class="pricing-section pricing-style-4 bg-light">
       <div class="container">
-        <div class="row align-items-center">
-          <div class="col-xl-5 col-lg-6">
-            <div class="section-title mb-60">
-              <h3 class="mb-15 wow fadeInUp" data-wow-delay=".2s">Pricing</h3>
-              <p class="wow fadeInUp" data-wow-delay=".4s">Straightforward packages for your next AI project.</p>
+        <div class="row justify-content-center">
+          <div class="col-xxl-6 col-xl-7 col-lg-8">
+            <div class="section-title text-center mb-60">
+              <h3 class="mb-15">🧾 Prosper Spot Plans</h3>
+              <p>No fluff. No fake limits. Just real tools, clear pricing, and freedom to build.</p>
             </div>
           </div>
-          <div class="col-xl-7 col-lg-6">
-            <div class="pricing-active-wrapper wow fadeInUp" data-wow-delay=".4s">
-              <div class="pricing-active">
-                <div class="single-pricing-wrapper">
-                  <div class="single-pricing">
-                    <h6>Basic Agent Build</h6>
-                    <h3>$49.00</h3>
-                    <ul>
-                      <li>Local or API chatbot (OpenWebUI or ChatGPT)</li>
-                      <li>Persona tuning</li>
-                      <li>Prompt memory included</li>
-                      <li>3-day turnaround</li>
-                    </ul>
-                    <a href="#contact" class="button radius-30">Get Started</a>
-                  </div>
-                </div>
-                <div class="single-pricing-wrapper">
-                  <div class="single-pricing">
-                    <h6>Full Book Generation</h6>
-                    <h3>$129.00</h3>
-                    <ul>
-                      <li>AI-drafted + revised novel or novella</li>
-                      <li>Based on outline or keywords</li>
-                      <li>Includes editing pass</li>
-                      <li>Delivered in .docx and .pdf</li>
-                    </ul>
-                    <a href="#contact" class="button radius-30">Get Started</a>
-                  </div>
-                </div>
-                <div class="single-pricing-wrapper">
-                  <div class="single-pricing">
-                    <h6>Custom LoRA Training</h6>
-                    <h3>$99.00</h3>
-                    <ul>
-                      <li>15–30 images</li>
-                      <li>Full training + weight file</li>
-                      <li>SDXL or 1.5</li>
-                      <li>Works with ControlNet/IP-Adapter</li>
-                    </ul>
-                    <a href="#contact" class="button radius-30">Get Started</a>
-                  </div>
-                </div>
-              </div>
+        </div>
+        <div class="row">
+          <div class="col-lg-3 col-md-6">
+            <div class="single-pricing">
+              <h6>🟢 Free</h6>
+              <h3>$0<span>/month</span></h3>
+              <p>Start creating without paying.</p>
+              <ul>
+                <li>About 25 chats per hour</li>
+                <li>10 images per month</li>
+                <li>Short-term memory for ongoing conversations</li>
+                <li>Works well for light use or one-off tasks</li>
+              </ul>
+              <a href="#" class="button radius-30">Choose Plan</a>
             </div>
+          </div>
+          <div class="col-lg-3 col-md-6">
+            <div class="single-pricing">
+              <h6>⚙️ Standard</h6>
+              <h3>$10<span>/month</span></h3>
+              <p>For people who use AI to get things done.</p>
+              <ul>
+                <li>About 250 chats per hour</li>
+                <li>Image generation included (safe content only)</li>
+                <li>Upload files for summaries or breakdowns</li>
+                <li>Faster replies and better answers</li>
+                <li>Built-in tools to improve prompt quality</li>
+              </ul>
+              <a href="#" class="button radius-30">Choose Plan</a>
+            </div>
+          </div>
+          <div class="col-lg-3 col-md-6">
+            <div class="single-pricing">
+              <h6>🚀 Pro</h6>
+              <h3>$20<span>/month</span></h3>
+              <p>Everything unlocked. No restrictions.</p>
+              <ul>
+                <li>Unlimited chat and image generation (within fair use)</li>
+                <li>Image generation that supports detailed and mature content</li>
+                <li>Ability to connect your own external AI tools</li>
+                <li>Access to exclusive agents like Riley</li>
+                <li>Early access to experimental features</li>
+                <li>Runs on higher-performance systems</li>
+              </ul>
+              <a href="#" class="button radius-30">Choose Plan</a>
+            </div>
+          </div>
+          <div class="col-lg-3 col-md-6">
+            <div class="single-pricing">
+              <h6>🎓 Student</h6>
+              <h3>$5<span>/month</span></h3>
+              <p>Same tools as Standard — focused on learning.</p>
+              <ul>
+                <li>Everything in Standard</li>
+                <li>Study tools for reviewing, organizing, and retaining information</li>
+              </ul>
+              <a href="#" class="button radius-30">Choose Plan</a>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-12 text-center mt-40">
+            <p class="mb-15">Need more advanced features?</p>
+            <a href="#contact" class="button radius-30">Contact Us</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- revamp pricing section with Prosper Spot plan tiers
- add contact CTA for advanced features

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890bf2209448326bd3a0661c7e18a94