### PR TITLE
style: match plans background and height

### DIFF
--- a/assets/css/lindy-uikit.css
+++ b/assets/css/lindy-uikit.css
@@ -840,7 +840,7 @@ p {
 ================================ */
 .pricing-style-4 {
   padding: 100px 0;
-  background: #F3F3F3;
+  background: #ffffff;
 }
 
 .pricing-style-4 .pricing-active-wrapper {
@@ -2395,18 +2395,18 @@ input:focus, textarea:focus, button:focus {
 /* ====== EQUAL HEIGHTS FOR CARDS ====== */
 .feature-style-5 .row > [class*='col'],
 .contact-style-3 .left-wrapper .row > [class*='col'],
-.pricing-style-4 .pricing-active .single-pricing-wrapper {
+.pricing-style-4 .row > [class*='col'] {
   display: flex;
 }
 
 .feature-style-5 .single-feature,
 .contact-style-3 .left-wrapper .single-item,
-.pricing-style-4 .pricing-active .single-pricing {
+.pricing-style-4 .single-pricing {
   flex: 1 1 auto;
 }
 
 .feature-style-5 .single-feature,
-.pricing-style-4 .pricing-active .single-pricing {
+.pricing-style-4 .single-pricing {
   display: flex;
   flex-direction: column;
 }

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
     </section>
     <!-- ========================= about style-4 end ========================= -->
     <!-- ========================= pricing style-4 start ========================= -->
-    <section id="pricing" class="pricing-section pricing-style-4 bg-light">
+    <section id="pricing" class="pricing-section pricing-style-4">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col-xxl-6 col-xl-7 col-lg-8">


### PR DESCRIPTION
## Summary
- Match pricing section background to services section for visual consistency
- Ensure pricing cards use flexbox to maintain equal heights

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c46789ec83269e7b74d657dfda42