### PR TITLE
Align pricing section styling with services

### DIFF
--- a/assets/css/lindy-uikit.css
+++ b/assets/css/lindy-uikit.css
@@ -835,6 +835,21 @@ p {
   margin-bottom: 25px;
 }
 
+.pricing-style-4 .single-pricing h3 {
+  margin-bottom: 18px;
+  color: #6E44FF;
+}
+
+.pricing-style-4 .single-pricing ul {
+  margin-bottom: 30px;
+}
+
+.pricing-style-4 .single-pricing ul li {
+  font-size: 16px;
+  line-height: 34px;
+  margin-bottom: 12px;
+}
+
 /* ============================= 
     PRICING-4 CSS
 ================================ */

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
     </section>
     <!-- ========================= about style-4 end ========================= -->
     <!-- ========================= pricing style-4 start ========================= -->
-    <section id="pricing" class="pricing-section pricing-style-4">
+    <section id="pricing" class="pricing-section pricing-style-4 feature-style-5">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col-xxl-6 col-xl-7 col-lg-8">
@@ -261,60 +261,68 @@
         </div>
         <div class="row">
           <div class="col-lg-3 col-md-6">
-            <div class="single-pricing">
-              <h6>🟢 Free</h6>
-              <h3>$0<span>/month</span></h3>
-              <p>Start creating without paying.</p>
-              <ul>
-                <li>About 25 chats per hour</li>
-                <li>10 images per month</li>
-                <li>Short-term memory for ongoing conversations</li>
-                <li>Works well for light use or one-off tasks</li>
-              </ul>
-              <a href="#" class="button radius-30">Choose Plan</a>
+            <div class="single-pricing single-feature">
+              <div class="content">
+                <h5>🟢 Free</h5>
+                <h3>$0<span>/month</span></h3>
+                <p>Start creating without paying.</p>
+                <ul>
+                  <li>About 25 chats per hour</li>
+                  <li>10 images per month</li>
+                  <li>Short-term memory for ongoing conversations</li>
+                  <li>Works well for light use or one-off tasks</li>
+                </ul>
+                <a href="#" class="button radius-30">Choose Plan</a>
+              </div>
             </div>
           </div>
           <div class="col-lg-3 col-md-6">
-            <div class="single-pricing">
-              <h6>⚙️ Standard</h6>
-              <h3>$10<span>/month</span></h3>
-              <p>For people who use AI to get things done.</p>
-              <ul>
-                <li>About 250 chats per hour</li>
-                <li>Image generation included (safe content only)</li>
-                <li>Upload files for summaries or breakdowns</li>
-                <li>Faster replies and better answers</li>
-                <li>Built-in tools to improve prompt quality</li>
-              </ul>
-              <a href="#" class="button radius-30">Choose Plan</a>
+            <div class="single-pricing single-feature">
+              <div class="content">
+                <h5>⚙️ Standard</h5>
+                <h3>$10<span>/month</span></h3>
+                <p>For people who use AI to get things done.</p>
+                <ul>
+                  <li>About 250 chats per hour</li>
+                  <li>Image generation included (safe content only)</li>
+                  <li>Upload files for summaries or breakdowns</li>
+                  <li>Faster replies and better answers</li>
+                  <li>Built-in tools to improve prompt quality</li>
+                </ul>
+                <a href="#" class="button radius-30">Choose Plan</a>
+              </div>
             </div>
           </div>
           <div class="col-lg-3 col-md-6">
-            <div class="single-pricing">
-              <h6>🚀 Pro</h6>
-              <h3>$20<span>/month</span></h3>
-              <p>Everything unlocked. No restrictions.</p>
-              <ul>
-                <li>Unlimited chat and image generation (within fair use)</li>
-                <li>Image generation that supports detailed and mature content</li>
-                <li>Ability to connect your own external AI tools</li>
-                <li>Access to exclusive agents like Riley</li>
-                <li>Early access to experimental features</li>
-                <li>Runs on higher-performance systems</li>
-              </ul>
-              <a href="#" class="button radius-30">Choose Plan</a>
+            <div class="single-pricing single-feature">
+              <div class="content">
+                <h5>🚀 Pro</h5>
+                <h3>$20<span>/month</span></h3>
+                <p>Everything unlocked. No restrictions.</p>
+                <ul>
+                  <li>Unlimited chat and image generation (within fair use)</li>
+                  <li>Image generation that supports detailed and mature content</li>
+                  <li>Ability to connect your own external AI tools</li>
+                  <li>Access to exclusive agents like Riley</li>
+                  <li>Early access to experimental features</li>
+                  <li>Runs on higher-performance systems</li>
+                </ul>
+                <a href="#" class="button radius-30">Choose Plan</a>
+              </div>
             </div>
           </div>
           <div class="col-lg-3 col-md-6">
-            <div class="single-pricing">
-              <h6>🎓 Student</h6>
-              <h3>$5<span>/month</span></h3>
-              <p>Same tools as Standard — focused on learning.</p>
-              <ul>
-                <li>Everything in Standard</li>
-                <li>Study tools for reviewing, organizing, and retaining information</li>
-              </ul>
-              <a href="#" class="button radius-30">Choose Plan</a>
+            <div class="single-pricing single-feature">
+              <div class="content">
+                <h5>🎓 Student</h5>
+                <h3>$5<span>/month</span></h3>
+                <p>Same tools as Standard — focused on learning.</p>
+                <ul>
+                  <li>Everything in Standard</li>
+                  <li>Study tools for reviewing, organizing, and retaining information</li>
+                </ul>
+                <a href="#" class="button radius-30">Choose Plan</a>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Reuse feature-style design for pricing section
- Standardize plan blocks with shared feature-style markup
- Add pricing-specific CSS for headings and lists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d729620c8326aaed15e45eea28f9