### PR TITLE
Add Supabase login integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ OWUI_API_BASE_URL=https://owui.example.com/api
 # Token used for Authorization: Bearer <token> or X-API-Key depending on your OWUI build
 OWUI_API_TOKEN=replace-with-your-token
 PORT=3000
+SUPABASE_URL=https://your-supabase-url.supabase.co
+SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ Website for simple online tools
 An Express webhook handler listens for Lemon Squeezy subscription events and
 provisions users in OWUI. Configure the environment variables listed in
 `.env.example` and start the server with `npm start`.
+
+## Supabase login
+
+A basic login page powered by Supabase is available at `login.html`. Configure your
+Supabase project credentials by setting `SUPABASE_URL` and `SUPABASE_ANON_KEY` in
+`.env` or directly in `assets/js/supabaseClient.js`.

--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -1,0 +1,14 @@
+document.getElementById('login-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+  const { error } = await window.supabaseClient.auth.signInWithPassword({ email, password });
+  const msgEl = document.getElementById('message');
+  if (error) {
+    msgEl.textContent = error.message;
+    msgEl.className = 'text-danger';
+  } else {
+    msgEl.textContent = 'Logged in successfully!';
+    msgEl.className = 'text-success';
+  }
+});

--- a/assets/js/supabaseClient.js
+++ b/assets/js/supabaseClient.js
@@ -1,0 +1,4 @@
+const SUPABASE_URL = 'https://your-supabase-url.supabase.co';
+const SUPABASE_ANON_KEY = 'your-supabase-anon-key';
+
+window.supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
                       <li class="nav-item">
                         <a class="page-scroll" href="#contact">Contact</a>
                       </li>
+                      <li class="nav-item">
+                        <a href="login.html">Login</a>
+                      </li>
                     </ul>
                   </div>
                   <div class="header-action d-flex">

--- a/login.html
+++ b/login.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Login - Prosper Spot</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="assets/css/bootstrap-5.0.0-beta1.min.css" />
+  <link rel="stylesheet" href="assets/css/lindy-uikit.css" />
+</head>
+<body>
+  <div class="container mt-5">
+    <h2>Login</h2>
+    <form id="login-form">
+      <div class="mb-3">
+        <label for="email" class="form-label">Email address</label>
+        <input type="email" class="form-control" id="email" required />
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" class="form-control" id="password" required />
+      </div>
+      <button type="submit" class="btn btn-primary">Login</button>
+    </form>
+    <div id="message" class="mt-3"></div>
+  </div>
+
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script src="assets/js/supabaseClient.js"></script>
+  <script src="assets/js/login.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic login page powered by Supabase Auth
- expose Supabase credentials via sample env file and client config
- link to login page from main navigation and document setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cda85a9248326b7a9c2a51822ed6d