### PR TITLE
Add select buttons with Lemon Squeezy checkout

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,9 +2,9 @@ module.exports = {
   planPrefix: 'plan:',
   planGroups: {
     // Map Lemon Squeezy variant IDs to OWUI group names
-    '12345': 'plan:basic',
-    '23456': 'plan:pro',
-    '34567': 'plan:enterprise',
+    '12345': 'plan:student',
+    '23456': 'plan:standard',
+    '34567': 'plan:pro',
   },
   grantStatuses: ['active', 'on_trial'],
   owui: {

--- a/index.html
+++ b/index.html
@@ -227,6 +227,7 @@
                 <h5>Free</h5>
                 <h3>$0<span>/month</span></h3>
                 <p>Chat without limits. No signup required. Great for casual use.</p>
+                <a href="https://chat.prosperspot.com" class="button radius-30 mt-15">Select</a>
               </div>
             </div>
           </div>
@@ -236,6 +237,7 @@
                 <h5>Student</h5>
                 <h3>$3<span>/month</span></h3>
                 <p>Study tools unlocked. Designed to help organize, remember, and learn faster.</p>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/12345" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
               </div>
             </div>
           </div>
@@ -245,6 +247,7 @@
                 <h5>Standard</h5>
                 <h3>$10<span>/month</span></h3>
                 <p>Saves longer chats, uploads images for summaries, better writing tools.</p>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/23456" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
               </div>
             </div>
           </div>
@@ -254,6 +257,7 @@
                 <h5>Pro</h5>
                 <h3>$20<span>/month</span></h3>
                 <p>Early access to new features. Dedicated server tier. Good for heavy users.</p>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/34567" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
               </div>
             </div>
           </div>
@@ -403,5 +407,6 @@
     <script src="assets/js/wow.min.js"></script>
     <script src="assets/js/main.js"></script>
     <script src="assets/js/contact.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add "Select" buttons for each pricing tier
- embed Lemon Squeezy checkout script and links
- map Lemon Squeezy variant IDs to plan groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce3d4984c8326b752cfccd803e819