### PR TITLE
Remove drop shadow and About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,9 +67,6 @@
                         <a class="page-scroll" href="#services">Features</a>
                       </li>
                       <li class="nav-item">
-                        <a class="page-scroll" href="#about">About</a>
-                      </li>
-                      <li class="nav-item">
                         <a class="page-scroll" href="#pricing">Pricing</a>
                       </li>
                       <li class="nav-item">
@@ -102,8 +99,8 @@
           <div class="row">
             <div class="col-lg-6">
               <div class="hero-content-wrapper">
-                <h2 class="mb-30 wow fadeInUp" data-wow-delay=".2s" style="text-shadow: 2px 2px;">Talk to an AI That Actually Works.</h2>
-                <p class="mb-30 wow fadeInUp" data-wow-delay=".4s" style="text-shadow: 2px 2px;">Real answers. Real utility. No gimmicks, no confusing limits, no corporate snooping.<br>Powered by open-source tools. Hosted by us. Simple as that.</p>
+                <h2 class="mb-30 wow fadeInUp" data-wow-delay=".2s">Talk to an AI That Actually Works.</h2>
+                <p class="mb-30 wow fadeInUp" data-wow-delay=".4s">Real answers. Real utility. No gimmicks, no confusing limits, no corporate snooping.<br>Powered by open-source tools. Hosted by us. Simple as that.</p>
                 <a href="https://chat.prosperspot.com" class="button button-lg radius-50 wow fadeInUp" data-wow-delay=".6s">Start Chatting – It&rsquo;s Free</a>
               </div>
             </div>
@@ -185,28 +182,6 @@
       </div>
     </section>
     <!-- ========================= feature style-5 end ========================= -->
-    <!-- ========================= about style-4 start ========================= -->
-    <section id="about" class="about-section about-style-4">
-      <div class="container">
-        <div class="row align-items-center">
-          <div class="col-xl-5 col-lg-6">
-            <div class="about-content-wrapper">
-              <div class="section-title mb-30">
-                  <h3 class="mb-25 wow fadeInUp" data-wow-delay=".2s">About Prosper Spot</h3>
-                  <p class="wow fadeInUp" data-wow-delay=".3s">We built this for people who just want AI to work. No API keys. No data mining. No &quot;pro&quot; paywalls for basic features. Just a clean, private chat tool that respects your time.</p>
-                  <p class="wow fadeInUp" data-wow-delay=".4s">Whether you're a student, a freelancer, or just curious — this is your AI assistant.</p>
-                </div>
-            </div>
-          </div>
-          <div class="col-xl-7 col-lg-6">
-            <div class="about-image text-lg-right wow fadeInUp" data-wow-delay=".5s">
-              <img src="assets/img/about/about-4/about-img.svg" alt="">
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-    <!-- ========================= about style-4 end ========================= -->
     <!-- ========================= pricing style-4 start ========================= -->
     <section id="pricing" class="pricing-section pricing-style-4 feature-style-5">
       <div class="container">


### PR DESCRIPTION
## Summary
- remove text drop shadow from hero headline and tagline
- remove About Prosper Spot navigation item and section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a213b9eea48326b8385bfbe40e5034