### PR TITLE
Force bright mode and remove pricing carousel

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -70,35 +70,7 @@
     window.document.addEventListener('scroll', onScroll);
     
 
-    // ===== pricing-style-4 slider
-    tns({
-        container: '.pricing-active',
-        autoplay: false,
-        mouseDrag: true,
-        gutter: 0,
-        nav: false,
-        controls: true,
-        controlsText: [
-          '<i class="lni lni-chevron-left prev"></i>',
-          '<i class="lni lni-chevron-right prev"></i>',
-        ],
-        responsive: {
-          0: {
-            items: 1,
-          },
-          768: {
-            items: 2,
-          },
-          992: {
-            items: 1.2,
-          },
-          1200: {
-            items: 2,
-          }
-        }
-      });
-
-	// WOW active
+    // WOW active
     new WOW().init();
 
 })();

--- a/index.html
+++ b/index.html
@@ -10,14 +10,10 @@
     <!-- ========================= CSS here ========================= -->
     <link rel="stylesheet" href="assets/css/bootstrap-5.0.0-beta1.min.css" />
     <link rel="stylesheet" href="assets/css/LineIcons.2.0.css"/>
-    <link rel="stylesheet" href="assets/css/tiny-slider.css"/>
     <link rel="stylesheet" href="assets/css/animate.css"/>
     <link rel="stylesheet" href="assets/css/lindy-uikit.css"/>
-    <link rel="stylesheet" href="assets/css/stars.css"/>
   </head>
-  <body>
-    <div id="stars"></div>
-    <div id="stars2"></div>
+  <body class="bg-white">
     <!--[if lte IE 9]>
       <p class="browserupgrade">
         You are using an <strong>outdated</strong> browser. Please
@@ -392,7 +388,6 @@
     <!-- ========================= scroll-top end ========================= -->
     <!-- ========================= JS here ========================= -->
     <script src="assets/js/bootstrap-5.0.0-beta1.min.js"></script>
-    <script src="assets/js/tiny-slider.js"></script>
     <script src="assets/js/wow.min.js"></script>
     <script src="assets/js/main.js"></script>
     <script src="assets/js/contact.js"></script>


### PR DESCRIPTION
## Summary
- Drop dark star background and enforce a white page background.
- Remove tiny-slider dependency and initialization so all pricing plans show together.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22c1e9c408326bb747106e5a70b47