### PR TITLE
Simplify Express server and webhook handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Website for simple online tools
 
 ## Webhook server
 
-An Express webhook handler listens for Lemon Squeezy subscription events and
-provisions users in OWUI. Configure the environment variables listed in
-`.env.example` and start the server with `npm start`.
+An Express webhook handler verifies Lemon Squeezy subscription events and logs
+them. Downstream processing (such as forwarding or queuing jobs) can be added in
+your own worker. Configure the environment variables listed in `.env.example`
+and start the server with `npm start`.
 
 ## Supabase login
 

--- a/server.js
+++ b/server.js
@@ -2,72 +2,16 @@ const path = require('path');
 const express = require('express');
 const crypto = require('crypto');
 
-const { recordEvent } = require('./db');
-const config = require('./config');
-const cookieDomain = process.env.COOKIE_DOMAIN || '.prosperspot.com';
-
-
 const PORT = process.env.PORT || 3000;
 const cookieDomain = process.env.COOKIE_DOMAIN || '.prosperspot.com';
 const LEMON_SECRET = process.env.LEMON_SQUEEZY_WEBHOOK_SECRET || '';
 
 const app = express();
 
+// ---- Static site (auth.html, assets, etc.) ----
+app.use(express.static(path.join(__dirname)));
 
-app.get('/healthz', (req, res) => res.json({ ok: true }));
-
-app.post('/session/set', express.json(), (req, res) => {
-  const accessToken = req.body?.access_token;
-  if (!accessToken) {
-    return res.status(400).json({ error: 'access_token required' });
-  }
-  res.setHeader(
-    'Set-Cookie',
-    `sb=${accessToken}; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; HttpOnly; Max-Age=3600`
-  );
-  res.json({ ok: true });
-});
-
-app.post('/session/clear', (req, res) => {
-  res.setHeader(
-    'Set-Cookie',
-    `sb=; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; Max-Age=0`
-  );
-  res.json({ ok: true });
-});
-
-app.get('/logout', (req, res) => {
-  res.setHeader(
-    'Set-Cookie',
-    `sb=; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; Max-Age=0`
-  );
-  res.redirect('/');
-});
-
-function fetchWithTimeout(url, opts = {}, timeout = 5000) {
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-  return fetch(url, { ...opts, signal: controller.signal })
-    .finally(() => clearTimeout(id));
-}
-
-// Use raw body for signature verification
-app.post('/webhooks/lemonsqueezy', express.raw({ type: 'application/json' }), async (req, res) => {
-  const signature = req.get('x-signature');
-  const eventId = req.get('x-event-id');
-
-  // Verify signature
-  const computed = crypto
-    .createHmac('sha256', config.lemonSqueezy.webhookSecret || '')
-    .update(req.body)
-    .digest('hex');
-  if (signature !== computed) {
-    console.error('Invalid signature', { eventId });
-    return res.status(400).send('Invalid signature');
-  }
-
-
-// Health
+// ---- Health ----
 app.get('/healthz', (req, res) => res.json({ ok: true }));
 
 // ---- Sessions ----
@@ -75,21 +19,24 @@ app.post('/session/set', express.json(), (req, res) => {
   const token = req.body?.access_token;
   if (!token) return res.status(400).json({ error: 'access_token required' });
 
-  res.setHeader('Set-Cookie',
+  res.setHeader(
+    'Set-Cookie',
     `sb=${token}; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; HttpOnly; Max-Age=3600`
   );
   res.json({ ok: true });
 });
 
 app.post('/session/clear', (req, res) => {
-  res.setHeader('Set-Cookie',
+  res.setHeader(
+    'Set-Cookie',
     `sb=; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; Max-Age=0`
   );
   res.json({ ok: true });
 });
 
 app.get('/logout', (req, res) => {
-  res.setHeader('Set-Cookie',
+  res.setHeader(
+    'Set-Cookie',
     `sb=; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; Max-Age=0`
   );
   res.redirect('/');
@@ -117,17 +64,15 @@ app.post('/webhooks/lemonsqueezy',
     try { event = JSON.parse(body.toString('utf8')); }
     catch { return res.status(400).send('Bad JSON'); }
 
-    // TODO: upsert into Supabase + enqueue OWUI /api/internal/upsert-users
-    // This part is environment-specific and you already have it in your Worker.
-    // You can either:
-    //  - keep using your Worker for cron syncing
-    //  - or mirror the logic here, calling OWUI directly with OWUI_API_TOKEN
+    console.log('Lemon Squeezy event', event.meta?.event_name, event.data?.attributes?.user_email);
 
+    // TODO: forward to your Worker or enqueue here for OWUI sync
+    // For now, just ack
     res.json({ status: 'ok' });
   }
 );
 
-// Fallback: JSON for non-matched POSTs
+// ---- Fallback JSON body parser (for other POSTs) ----
 app.use(express.json());
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- streamline Express server to serve static assets, handle Supabase session cookies, and verify Lemon Squeezy webhooks
- clarify README for new webhook verification behavior

## Testing
- `npm test`
- `node server.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8e8541af083268de058d607e22c4c