### PR TITLE
Simplify auth to rely on Supabase client-side session

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ and start the server with `npm start`.
 
 ## Supabase login
 
-An auth page powered by Supabase is available at `auth.html`. It supports password
-and magic link login. On successful sign in the page posts the session's access
-token to `/session/set`, which stores it as an `sb` cookie for `.prosperspot.com`.
-`logout.html` signs out and then hits `/logout`, which clears the cookie and
-redirects home.
-Configure your Supabase project credentials by setting `SUPABASE_URL` and
-`SUPABASE_ANON_KEY` in `.env` or directly in `assets/js/supabaseClient.js`.
+An auth page powered by Supabase is available at `auth.html`. It supports
+password and magic link login. Sessions persist client-side with Supabase; on
+sign in the page redirects to the requested path. `logout.html` signs out via
+Supabase and then redirects to `auth.html`. Configure your Supabase project
+credentials by setting `SUPABASE_URL` and `SUPABASE_ANON_KEY` in `.env` or
+directly in `assets/js/supabaseClient.js`.

--- a/assets/js/auth-gate.js
+++ b/assets/js/auth-gate.js
@@ -1,9 +1,6 @@
-(function () {
-  function getCookie(name) {
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) return parts.pop().split(';').shift();
-  }
-  const token = getCookie('sb');
-  if (!token) window.location.href = '/auth.html';
+(async () => {
+  const {
+    data: { session },
+  } = await window.supabaseClient.auth.getSession();
+  if (!session) window.location.href = '/auth.html';
 })();

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -3,25 +3,11 @@ const msgEl = document.getElementById('message');
 const magicBtn = document.getElementById('magic-link');
 
 const params = new URLSearchParams(window.location.search);
-const redirect = params.get('redirect') || 'https://dev.prosperspot.com/';
+const redirectParam = params.get('redirect');
+const redirect = redirectParam && redirectParam.startsWith('/') ? redirectParam : '/';
 
-async function storeSession(access_token) {
-  try {
-    await fetch('/session/set', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ access_token }),
-    });
-  } catch (err) {
-    console.error('Failed to set session', err);
-  }
-}
-
-async function handleSession(session) {
+function handleSession(session) {
   if (!session) return;
-  console.log('access token', session.access_token);
-  await storeSession(session.access_token);
   window.location.href = redirect;
 }
 
@@ -46,7 +32,6 @@ form.addEventListener('submit', async (e) => {
     msgEl.className = 'text-danger';
     return;
   }
-  await handleSession(data.session);
 });
 
 magicBtn.addEventListener('click', async () => {

--- a/logout.html
+++ b/logout.html
@@ -17,13 +17,6 @@
         await window.supabaseClient.auth.signOut();
       } catch (e) {}
 
-      try {
-        await fetch('/session/clear', {
-          method: 'POST',
-          credentials: 'include',
-        });
-      } catch (e) {}
-
       window.location.href = '/auth.html';
     })();
   </script>

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ const express = require('express');
 const crypto = require('crypto');
 
 const PORT = process.env.PORT || 3000;
-const cookieDomain = process.env.COOKIE_DOMAIN || '.prosperspot.com';
 const LEMON_SECRET = process.env.LEMON_SQUEEZY_WEBHOOK_SECRET || '';
 
 const app = express();
@@ -14,33 +13,6 @@ app.use(express.static(path.join(__dirname)));
 // ---- Health ----
 app.get('/healthz', (req, res) => res.json({ ok: true }));
 
-// ---- Sessions ----
-app.post('/session/set', express.json(), (req, res) => {
-  const token = req.body?.access_token;
-  if (!token) return res.status(400).json({ error: 'access_token required' });
-
-  res.setHeader(
-    'Set-Cookie',
-    `sb=${token}; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; HttpOnly; Max-Age=3600`
-  );
-  res.json({ ok: true });
-});
-
-app.post('/session/clear', (req, res) => {
-  res.setHeader(
-    'Set-Cookie',
-    `sb=; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; Max-Age=0`
-  );
-  res.json({ ok: true });
-});
-
-app.get('/logout', (req, res) => {
-  res.setHeader(
-    'Set-Cookie',
-    `sb=; Domain=${cookieDomain}; Path=/; Secure; SameSite=None; Max-Age=0`
-  );
-  res.redirect('/');
-});
 
 // ---- Lemon Squeezy webhook ----
 // IMPORTANT: raw body ONLY for this one route.


### PR DESCRIPTION
## Summary
- Replace cookie-based gate with Supabase session check
- Remove server session endpoints and cookie handling
- Clean up auth flows: no token logging, validated redirects, simplified logout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa64448bf08326b282e2ba1b166770