### PR TITLE
Configure Supabase via env script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ LEMON_SQUEEZY_WEBHOOK_SECRET=replace-with-your-signing-secret
 OWUI_API_BASE_URL=https://owui.example.com/api
 OWUI_API_TOKEN=replace-with-your-token
 PORT=3000
-SUPABASE_URL=https://your-supabase-url.supabase.co
-SUPABASE_ANON_KEY=your-supabase-anon-key
+# Supabase credentials for local development
+SUPABASE_URL=https://oreyljqmoojibfvrwvay.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9yZXlsanFtb29qaWJmdnJ3dmF5Iiwicm9sZSI6ImFub24iLCJleHAiOjE4MDAwMDAwMDB9.qrQEM7J4VfnWD3c91fhNwTE3vXcIzBgE4c3OJbGdv8E
 COOKIE_DOMAIN=.prosperspot.com

--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ An auth page powered by Supabase is available at `auth.html`. It supports
 password and magic link login. Sessions persist client-side with Supabase; on
 sign in the page redirects to the requested path. `logout.html` signs out via
 Supabase and then redirects to `auth.html`. Configure your Supabase project
-credentials by setting `SUPABASE_URL` and `SUPABASE_ANON_KEY` in `.env` or
-directly in `assets/js/supabaseClient.js`.
+credentials by editing `assets/js/supabaseEnv.js`, which sets
+`window.SUPABASE_URL` and `window.SUPABASE_ANON_KEY` before
+`assets/js/supabaseClient.js` loads.

--- a/assets/js/supabaseClient.js
+++ b/assets/js/supabaseClient.js
@@ -1,9 +1,6 @@
-// Allow overriding via globals set by the hosting page. Fallback to placeholders
-// that can be replaced at deploy time or during development.
-const SUPABASE_URL =
-  window.SUPABASE_URL || 'https://your-supabase-url.supabase.co';
-const SUPABASE_ANON_KEY =
-  window.SUPABASE_ANON_KEY || 'your-supabase-anon-key';
+// Supabase credentials are provided via globals defined before this script loads.
+const SUPABASE_URL = window.SUPABASE_URL;
+const SUPABASE_ANON_KEY = window.SUPABASE_ANON_KEY;
 
 window.supabaseClient = window.supabase.createClient(
   SUPABASE_URL,

--- a/assets/js/supabaseEnv.js
+++ b/assets/js/supabaseEnv.js
@@ -1,0 +1,2 @@
+window.SUPABASE_URL = 'https://oreyljqmoojibfvrwvay.supabase.co';
+window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9yZXlsanFtb29qaWJmdnJ3dmF5Iiwicm9sZSI6ImFub24iLCJleHAiOjE4MDAwMDAwMDB9.qrQEM7J4VfnWD3c91fhNwTE3vXcIzBgE4c3OJbGdv8E';

--- a/auth.html
+++ b/auth.html
@@ -13,12 +13,12 @@
     <form id="login-form">
       <div class="mb-3">
         <label for="email" class="form-label">Email address</label>
-        <input type="email" class="form-control" id="email" required />
+        <input type="email" class="form-control" id="email" autocomplete="email" required />
       </div>
       <div class="mb-3">
         <label for="password" class="form-label">Password (optional if using magic link)</label>
 
-        <input type="password" class="form-control" id="password" />
+        <input type="password" class="form-control" id="password" autocomplete="current-password" />
       </div>
       <div class="d-flex gap-2">
         <button type="submit" class="btn btn-primary">Login</button>
@@ -29,6 +29,7 @@
   </div>
 
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script src="assets/js/supabaseEnv.js"></script>
   <script src="assets/js/supabaseClient.js"></script>
   <script src="assets/js/auth.js"></script>
 </body>

--- a/logout.html
+++ b/logout.html
@@ -9,6 +9,7 @@
 <body>
   <p class="text-center mt-5">Logging out...</p>
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script src="assets/js/supabaseEnv.js"></script>
   <script src="assets/js/supabaseClient.js"></script>
   <script>
     (async () => {


### PR DESCRIPTION
## Summary
- load real Supabase project credentials from a shared `supabaseEnv.js`
- instantiate the Supabase client only from pre-defined globals
- improve auth form usability with autocomplete attributes and correct script order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab0f1708688326aec27da421fc88a5