### PR TITLE
Ensure single Supabase init and bust stale script caches

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -29,8 +29,8 @@
   </div>
 
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
-  <script src="assets/js/supabaseEnv.js"></script>
-  <script src="assets/js/supabaseClient.js"></script>
+  <script src="assets/js/supabaseEnv.js?v=2"></script>
+  <script src="assets/js/supabaseClient.js?v=2"></script>
   <script src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/logout.html
+++ b/logout.html
@@ -9,8 +9,8 @@
 <body>
   <p class="text-center mt-5">Logging out...</p>
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
-  <script src="assets/js/supabaseEnv.js"></script>
-  <script src="assets/js/supabaseClient.js"></script>
+  <script src="assets/js/supabaseEnv.js?v=2"></script>
+  <script src="assets/js/supabaseClient.js?v=2"></script>
   <script>
     (async () => {
 


### PR DESCRIPTION
## Summary
- Verify `supabaseEnv.js` holds only the current anon key
- Add cache-busting query params to Supabase environment and client scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab1cfa67848326bbd259a9b0bd8b6f