### PR TITLE
Update Lemon Squeezy product links

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,9 +2,9 @@ module.exports = {
   planPrefix: 'plan:',
   planGroups: {
     // Map Lemon Squeezy variant IDs to OWUI group names
-    '12345': 'plan:student',
-    '23456': 'plan:standard',
-    '34567': 'plan:pro',
+      '606476': 'plan:student',
+      '606477': 'plan:standard',
+      '606478': 'plan:pro',
   },
   grantStatuses: ['active', 'on_trial'],
   owui: {

--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
                   <li>Step-by-step problem help</li>
                   <li>Essay + writing support</li>
                 </ul>
-                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/12345" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606476" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
               </div>
             </div>
           </div>
@@ -215,7 +215,7 @@
                   <li>Essay + writing support</li>
                   <li>Half the cost of the other guys.</li>
                 </ul>
-                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/23456" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
               </div>
             </div>
           </div>
@@ -231,7 +231,7 @@
                   <li>Advance models including Qwen3 235B & Llama3.1 405B</li>
                   <li>Access to advanced reasoning tools (limited queries per month)</li>
                 </ul>
-                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/34567" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606478" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- replace placeholder checkout links with real Lemon Squeezy product IDs for Student, Standard and Pro plans
- align server config to map new variant IDs to plan groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab31b292b08326ae739bc635307e2c