### PR TITLE
Add login modal with close button

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -5,6 +5,7 @@ const magicBtn = document.getElementById('magic-link');
 const params = new URLSearchParams(window.location.search);
 const redirectParam = params.get('redirect');
 const redirect = redirectParam && redirectParam.startsWith('/') ? redirectParam : '/';
+const onAuthPage = window.location.pathname.includes('auth.html');
 
 function handleSession(session) {
   if (!session) return;
@@ -13,10 +14,12 @@ function handleSession(session) {
 
 // Handle already-logged-in users or magic-link callbacks
 window.supabaseClient.auth.getSession().then(({ data }) => {
-  if (data.session) handleSession(data.session);
+  if (data.session && onAuthPage) handleSession(data.session);
 });
-window.supabaseClient.auth.onAuthStateChange((_event, session) => {
-  if (session) handleSession(session);
+window.supabaseClient.auth.onAuthStateChange((event, session) => {
+  if (session && (event === 'SIGNED_IN' || (event === 'INITIAL_SESSION' && onAuthPage))) {
+    handleSession(session);
+  }
 });
 
 form.addEventListener('submit', async (e) => {

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
                         <a class="page-scroll" href="#contact">Contact</a>
                       </li>
                       <li class="nav-item">
-                        <a href="auth.html">Login</a>
+                        <a href="#" data-bs-toggle="modal" data-bs-target="#loginModal">Login</a>
                       </li>
                     </ul>
                   </div>
@@ -362,11 +362,43 @@
     <!-- ========================= scroll-top start ========================= -->
     <a href="#" class="scroll-top"> <i class="lni lni-chevron-up"></i> </a>
     <!-- ========================= scroll-top end ========================= -->
+    <!-- Login Modal -->
+    <div class="modal fade" id="loginModal" tabindex="-1" aria-labelledby="loginModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="loginModalLabel">Sign In</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <form id="login-form">
+              <div class="mb-3">
+                <label for="email" class="form-label">Email address</label>
+                <input type="email" class="form-control" id="email" autocomplete="email" required />
+              </div>
+              <div class="mb-3">
+                <label for="password" class="form-label">Password (optional if using magic link)</label>
+                <input type="password" class="form-control" id="password" autocomplete="current-password" />
+              </div>
+              <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Login</button>
+                <button type="button" id="magic-link" class="btn btn-secondary">Send Magic Link</button>
+              </div>
+            </form>
+            <div id="message" class="mt-3 text-center"></div>
+          </div>
+        </div>
+      </div>
+    </div>
     <!-- ========================= JS here ========================= -->
     <script src="assets/js/bootstrap-5.0.0-beta1.min.js"></script>
     <script src="assets/js/wow.min.js"></script>
     <script src="assets/js/main.js"></script>
     <script src="assets/js/contact.js"></script>
     <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="assets/js/supabaseEnv.js?v=2"></script>
+    <script src="assets/js/supabaseClient.js?v=2"></script>
+    <script src="assets/js/auth.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace navbar login link with modal trigger
- add Bootstrap login modal with form and close button
- adjust auth logic to avoid redirect loop when modal is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab34b88cf08326aeb02e2ab6220fbe