### PR TITLE
Add early-access invite modal for product links

### DIFF
--- a/assets/js/early-access.js
+++ b/assets/js/early-access.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('early-access-modal');
+  if (!modalEl) return;
+  const modal = new bootstrap.Modal(modalEl);
+  const triggers = document.querySelectorAll('.product-popup');
+  triggers.forEach((el) => {
+    el.addEventListener('click', (e) => {
+      e.preventDefault();
+      modal.show();
+    });
+  });
+
+  const form = modalEl.querySelector('form');
+  const emailInput = form.querySelector('input[type="email"]');
+  const messageEl = modalEl.querySelector('.message');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = emailInput.value.trim();
+    messageEl.textContent = '';
+    try {
+      const res = await fetch('/request-invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      if (res.ok) {
+        messageEl.textContent = 'Request sent!';
+        form.reset();
+      } else {
+        messageEl.textContent = 'Failed to send. Please try again.';
+      }
+    } catch {
+      messageEl.textContent = 'Failed to send. Please try again.';
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
               <div class="hero-content-wrapper">
                 <h2 class="mb-30 wow fadeInUp" data-wow-delay=".2s">Study Smarter. Pay Less.</h2>
                 <p class="mb-30 wow fadeInUp" data-wow-delay=".4s">Every subject comes with a tuned AI study companion built on trusted textbooks. Clear explanations, real examples, and step-by-step help that actually makes sense.</p>
-                <a href="https://chat.prosperspot.com" class="button button-lg radius-50 wow fadeInUp" data-wow-delay=".6s">Start Studying</a>
+                  <a href="https://chat.prosperspot.com" class="button button-lg radius-50 wow fadeInUp product-popup" data-wow-delay=".6s">Start Studying</a>
               </div>
             </div>
           </div>
@@ -200,7 +200,7 @@
                   <li>Step-by-step problem help</li>
                   <li>Essay + writing support</li>
                 </ul>
-                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606476" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606476" class="button radius-30 mt-15 lemonsqueezy-button product-popup">Select</a>
               </div>
             </div>
           </div>
@@ -215,7 +215,7 @@
                   <li>Essay + writing support</li>
                   <li>Half the cost of the other guys.</li>
                 </ul>
-                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="button radius-30 mt-15 lemonsqueezy-button product-popup">Select</a>
               </div>
             </div>
           </div>
@@ -231,7 +231,7 @@
                   <li>Advance models including Qwen3 235B & Llama3.1 405B</li>
                   <li>Access to advanced reasoning tools (limited queries per month)</li>
                 </ul>
-                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606478" class="button radius-30 mt-15 lemonsqueezy-button">Select</a>
+                <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606478" class="button radius-30 mt-15 lemonsqueezy-button product-popup">Select</a>
               </div>
             </div>
           </div>
@@ -240,7 +240,7 @@
           <div class="col-12 mt-40 d-flex flex-column align-items-center text-center">
             <h4 class="mb-15">Try It Out Now</h4>
             <p>Ask a question. See a real answer backed by a textbook. Upgrade only if it actually helps you study better.</p>
-            <a href="https://chat.prosperspot.com" class="button radius-30 mt-15">Launch Chat</a>
+            <a href="https://chat.prosperspot.com" class="button radius-30 mt-15 product-popup">Launch Chat</a>
           </div>
         </div>
       </div>
@@ -362,11 +362,27 @@
     <!-- ========================= scroll-top start ========================= -->
     <a href="#" class="scroll-top"> <i class="lni lni-chevron-up"></i> </a>
     <!-- ========================= scroll-top end ========================= -->
+    <div class="modal fade" id="early-access-modal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">🔒 Early access only. Request an invite.</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <form class="modal-body">
+            <input type="email" class="form-control mb-3" placeholder="you@example.com" required>
+            <button type="submit" class="btn btn-primary w-100">Send</button>
+            <div class="mt-2 message"></div>
+          </form>
+        </div>
+      </div>
+    </div>
     <!-- ========================= JS here ========================= -->
     <script src="assets/js/bootstrap-5.0.0-beta1.min.js"></script>
     <script src="assets/js/wow.min.js"></script>
     <script src="assets/js/main.js"></script>
     <script src="assets/js/contact.js"></script>
+    <script src="assets/js/early-access.js"></script>
     <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^9.6.0",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "nodemailer": "^6.10.1"
       }
     },
     "node_modules/accepts": {
@@ -725,6 +726,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "better-sqlite3": "^9.6.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "nodemailer": "^6.10.1"
   }
 }


### PR DESCRIPTION
## Summary
- show an early-access modal for product call-to-action links
- collect email addresses and send invite requests to admin via nodemailer

## Testing
- `npm test`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab37398fd88326b97543a07a7965de