### PR TITLE
Remove marketing sections from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,22 +54,6 @@
                         <a href="#" class="btn btn-primary btn-large">Get Started Free</a>
                         <a href="#" class="btn btn-secondary btn-large">Learn More</a>
                     </div>
-                    <div class="hero-trust animate-on-scroll">
-                        <p>Trusted by teams at</p>
-                        <div class="logos">
-                            <img src="https://placehold.co/120x40?text=Logo+1" alt="Logo 1">
-                            <img src="https://placehold.co/120x40?text=Logo+2" alt="Logo 2">
-                            <img src="https://placehold.co/120x40?text=Logo+3" alt="Logo 3">
-                            <img src="https://placehold.co/120x40?text=Logo+4" alt="Logo 4">
-                        </div>
-                    </div>
-                    <p class="animate-on-scroll">No install. No limits on curiosity.</p>
-                    <ul class="subheadline-links animate-on-scroll">
-                        <li><a href="#">Study Tools</a></li>
-                        <li><a href="#">Chat Assistants</a></li>
-                        <li><a href="#">Prompt Packs</a></li>
-                        <li><a href="#">Open Projects</a></li>
-                    </ul>
                 </div>
             </div>
         </section>
@@ -98,56 +82,6 @@
                 </div>
                 <div class="showcase-wrapper animate-on-scroll">
                     <img src="https://placehold.co/1000x600/13122C/FFFFFF?text=Demo+Placeholder" alt="Prosper Spot demo" class="showcase-image">
-                </div>
-            </div>
-        </section>
-
-        <!-- Steps Section -->
-        <section class="steps">
-            <div class="container">
-                <div class="section-header">
-                    <h2 class="animate-on-scroll">Connect. Design. Activate.</h2>
-                    <p class="animate-on-scroll">Build your workflow in three simple steps.</p>
-                </div>
-                <div class="steps-container">
-                    <div class="step-card animate-on-scroll">
-                        <span>1</span>
-                        <div class="icon-wrapper"><i data-feather="plug"></i></div>
-                        <h3>Connect</h3>
-                        <p>Hook Prosper Spot into the tools you already rely on. No installs or complicated setup.</p>
-                    </div>
-                    <div class="step-connector"></div>
-                    <div class="step-card animate-on-scroll">
-                        <span>2</span>
-                        <div class="icon-wrapper"><i data-feather="pen-tool"></i></div>
-                        <h3>Design</h3>
-                        <p>Use our visual builder to craft prompts and flows that match your process and goals.</p>
-                    </div>
-                    <div class="step-connector"></div>
-                    <div class="step-card animate-on-scroll">
-                        <span>3</span>
-                        <div class="icon-wrapper"><i data-feather="zap"></i></div>
-                        <h3>Activate</h3>
-                        <p>Deploy your custom AI co‑pilot across your business and iterate as you grow.</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Ecosystem Logos Row -->
-        <section class="integrations">
-            <div class="container">
-                <div class="section-header">
-                    <h2 class="animate-on-scroll">Works With Your Stack</h2>
-                    <p class="animate-on-scroll">Prosper Spot plugs into the tools you use every day.</p>
-                </div>
-                <div class="logo-wall">
-                    <div class="logo-item"><img src="https://placehold.co/120x60?text=Logo+A" alt="Integration A"></div>
-                    <div class="logo-item"><img src="https://placehold.co/120x60?text=Logo+B" alt="Integration B"></div>
-                    <div class="logo-item"><img src="https://placehold.co/120x60?text=Logo+C" alt="Integration C"></div>
-                    <div class="logo-item"><img src="https://placehold.co/120x60?text=Logo+D" alt="Integration D"></div>
-                    <div class="logo-item"><img src="https://placehold.co/120x60?text=Logo+E" alt="Integration E"></div>
-                    <div class="logo-item"><img src="https://placehold.co/120x60?text=Logo+F" alt="Integration F"></div>
                 </div>
             </div>
         </section>
@@ -217,20 +151,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
-        </section>
-
-        <!-- Ecosystem Details -->
-        <section class="hub-positioning">
-            <div class="container">
-                <ul class="list-disc list-inside text-white text-sm leading-relaxed space-y-2 font-sans">
-                    <li>AI powered prompt packs</li>
-                    <li>Tuned companions for specific workflows</li>
-                    <li>Public datasets</li>
-                    <li>Open infrastructure</li>
-                    <li>Learning resources</li>
-                    <li>Want to build with us? Join the waitlist.</li>
-                </ul>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- remove hero trust logos and subheadline links
- strip multi-step and integration sections
- drop final ecosystem bullet list before FAQ

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ace2fdb4f88326b3ccb84bef59075e