### PR TITLE
Add pricing, onboarding, and account pages

### DIFF
--- a/account.html
+++ b/account.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Your Account - Prosper Spot</title>
+    <link rel="icon" type="image/png" href="assets/img/ps-favicon.png" />
+    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://unpkg.com/feather-icons" crossorigin="anonymous"></script>
+</head>
+<body>
+    <div class="background-glow"></div>
+    <header>
+        <div class="container">
+            <nav>
+                <a href="index.html" class="logo">
+                    <img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="32" />
+                    <span>Prosper Spot</span>
+                </a>
+                <ul class="nav-links">
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="#">Study</a></li>
+                    <li><a href="#">Tools</a></li>
+                    <li><a href="account.html">Account</a></li>
+                    <li><a href="#">Support</a></li>
+                </ul>
+                <div class="nav-buttons">
+                    <a href="auth.html" class="btn btn-secondary">Log In</a>
+                    <a href="pricing.html" class="btn btn-primary">Upgrade</a>
+                </div>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Open Menu">
+                    <i data-feather="menu"></i>
+                </button>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <section class="pricing">
+            <div class="container">
+                <div class="section-header">
+                    <h1>Your Account</h1>
+                </div>
+                <div class="account-info">
+                    <p><strong>Plan:</strong> Standard</p>
+                    <p><strong>Renews:</strong> October 1, 2024</p>
+                    <div class="usage">
+                        <label>Messages used today</label>
+                        <progress value="0" max="100"></progress>
+                        <span>0 / 100</span>
+                    </div>
+                    <p><a href="#" class="btn btn-secondary">Manage billing</a></p>
+                </div>
+            </div>
+        </section>
+    </main>
+    <script src="assets/js/script.js"></script>
+    <script>feather.replace();</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -23,17 +23,20 @@
     <header>
         <div class="container">
             <nav>
-                <a href="#" class="logo">
+                <a href="index.html" class="logo">
                     <img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="32" />
                     <span>Prosper Spot</span>
                 </a>
                 <ul class="nav-links">
-                    <li><a href="#features">Features</a></li>
-                    <li><a href="#pricing">Pricing</a></li>
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="#">Study</a></li>
+                    <li><a href="#">Tools</a></li>
+                    <li><a href="account.html">Account</a></li>
+                    <li><a href="#">Support</a></li>
                 </ul>
                 <div class="nav-buttons">
-                    <a href="#" class="btn btn-secondary">Log In</a>
-                    <a href="#" class="btn btn-primary">Get Started Free</a>
+                    <a href="auth.html" class="btn btn-secondary">Log In</a>
+                    <a href="pricing.html" class="btn btn-primary">Upgrade</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Open Menu">
                     <i data-feather="menu"></i>
@@ -97,36 +100,47 @@
                 </div>
                 <div class="pricing-grid">
                     <div class="pricing-card animate-on-scroll">
+                        <h3>Free</h3>
+                        <p class="price-desc">Start experimenting</p>
+                        <div class="price"><sup>$</sup>0<span>/mo</span></div>
+                        <ul>
+                            <li><i data-feather="check-circle"></i> Basic answers</li>
+                        </ul>
+                        <a href="#" class="btn btn-primary">Start Free →</a>
+                    </div>
+                    <div class="pricing-card animate-on-scroll">
                         <h3>Student</h3>
-                        <p class="price-desc">For learners, classrooms, and academic tools</p>
+                        <p class="price-desc">For learners and classrooms</p>
                         <div class="price"><sup>$</sup>5<span>/mo</span></div>
                         <ul>
-                            <li><i data-feather="check-circle"></i> Full access to tuned AIs</li>
-                            <li><i data-feather="check-circle"></i> Study tools, writing help, research support</li>
+                            <li><i data-feather="check-circle"></i> Faster answers</li>
+                            <li><i data-feather="check-circle"></i> Larger context</li>
                         </ul>
-                        <a href="#" class="btn btn-primary">Choose Student Plan →</a>
+                        <a href="#" class="btn btn-primary">Choose Student →</a>
                     </div>
                     <div class="pricing-card popular animate-on-scroll">
                         <div class="popular-badge">Most Popular</div>
                         <h3>Standard</h3>
-                        <p class="price-desc">For anyone who wants fast, reliable AI — minus the fluff</p>
+                        <p class="price-desc">For reliable everyday AI</p>
                         <div class="price"><sup>$</sup>10<span>/mo</span></div>
                         <ul>
-                            <li><i data-feather="check-circle"></i> Everything in Student, no ID required</li>
-                            <li><i data-feather="check-circle"></i> Priority access, better performance</li>
+                            <li><i data-feather="check-circle"></i> Faster answers</li>
+                            <li><i data-feather="check-circle"></i> Larger context</li>
+                            <li><i data-feather="check-circle"></i> Priority queue</li>
                         </ul>
-                        <a href="#" class="btn btn-primary">Choose Standard Plan →</a>
+                        <a href="#" class="btn btn-primary">Choose Standard →</a>
                     </div>
                     <div class="pricing-card animate-on-scroll">
                         <h3>Pro</h3>
-                        <p class="price-desc">For builders, devs, and power users</p>
+                        <p class="price-desc">For builders and power users</p>
                         <div class="price"><sup>$</sup>20<span>/mo</span></div>
                         <ul>
-                            <li><i data-feather="check-circle"></i> Access to top-tier models</li>
-                            <li><i data-feather="check-circle"></i> Developer tools, advanced features</li>
-                            <li><i data-feather="check-circle"></i> Ideal for daily heavy use</li>
+                            <li><i data-feather="check-circle"></i> Faster answers</li>
+                            <li><i data-feather="check-circle"></i> Larger context</li>
+                            <li><i data-feather="check-circle"></i> Priority queue</li>
+                            <li><i data-feather="check-circle"></i> Advanced tools</li>
                         </ul>
-                        <a href="#" class="btn btn-primary">Choose Pro Plan →</a>
+                        <a href="#" class="btn btn-primary">Choose Pro →</a>
                     </div>
                 </div>
             </div>

--- a/onboarding.html
+++ b/onboarding.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to Prosper Spot</title>
+    <link rel="icon" type="image/png" href="assets/img/ps-favicon.png" />
+    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://unpkg.com/feather-icons" crossorigin="anonymous"></script>
+</head>
+<body>
+    <div class="background-glow"></div>
+    <main>
+        <section class="hero">
+            <div class="container">
+                <div class="hero-content">
+                    <h1>Pick your study buddy, tools, and limits</h1>
+                    <p>You're all set! Customize how you work with AI and get more when you upgrade.</p>
+                    <a href="pricing.html" class="btn btn-primary btn-large">Upgrade →</a>
+                </div>
+            </div>
+        </section>
+    </main>
+    <script src="assets/js/script.js"></script>
+    <script>feather.replace();</script>
+</body>
+</html>

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pricing - Prosper Spot</title>
+    <link rel="icon" type="image/png" href="assets/img/ps-favicon.png" />
+    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://unpkg.com/feather-icons" crossorigin="anonymous"></script>
+</head>
+<body>
+    <div class="background-glow"></div>
+    <header>
+        <div class="container">
+            <nav>
+                <a href="index.html" class="logo">
+                    <img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="32" />
+                    <span>Prosper Spot</span>
+                </a>
+                <ul class="nav-links">
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="#">Study</a></li>
+                    <li><a href="#">Tools</a></li>
+                    <li><a href="account.html">Account</a></li>
+                    <li><a href="#">Support</a></li>
+                </ul>
+                <div class="nav-buttons">
+                    <a href="auth.html" class="btn btn-secondary">Log In</a>
+                    <a href="pricing.html" class="btn btn-primary">Upgrade</a>
+                </div>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Open Menu">
+                    <i data-feather="menu"></i>
+                </button>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <section class="pricing">
+            <div class="container">
+                <div class="section-header">
+                    <h1>Choose Your Plan</h1>
+                    <p>No model names, just benefits.</p>
+                </div>
+                <div class="pricing-grid">
+                    <div class="pricing-card">
+                        <h3>Free</h3>
+                        <p class="price-desc">Start experimenting</p>
+                        <div class="price"><sup>$</sup>0<span>/mo</span></div>
+                        <ul>
+                            <li><i data-feather="check-circle"></i> Basic answers</li>
+                        </ul>
+                        <a href="#" class="btn btn-primary">Start Free →</a>
+                    </div>
+                    <div class="pricing-card">
+                        <h3>Student</h3>
+                        <p class="price-desc">For learners and classrooms</p>
+                        <div class="price"><sup>$</sup>5<span>/mo</span></div>
+                        <ul>
+                            <li><i data-feather="check-circle"></i> Faster answers</li>
+                            <li><i data-feather="check-circle"></i> Larger context</li>
+                        </ul>
+                        <a href="#" class="btn btn-primary">Choose Student →</a>
+                    </div>
+                    <div class="pricing-card popular">
+                        <div class="popular-badge">Most Popular</div>
+                        <h3>Standard</h3>
+                        <p class="price-desc">For reliable everyday AI</p>
+                        <div class="price"><sup>$</sup>10<span>/mo</span></div>
+                        <ul>
+                            <li><i data-feather="check-circle"></i> Faster answers</li>
+                            <li><i data-feather="check-circle"></i> Larger context</li>
+                            <li><i data-feather="check-circle"></i> Priority queue</li>
+                        </ul>
+                        <a href="#" class="btn btn-primary">Choose Standard →</a>
+                    </div>
+                    <div class="pricing-card">
+                        <h3>Pro</h3>
+                        <p class="price-desc">For builders and power users</p>
+                        <div class="price"><sup>$</sup>20<span>/mo</span></div>
+                        <ul>
+                            <li><i data-feather="check-circle"></i> Faster answers</li>
+                            <li><i data-feather="check-circle"></i> Larger context</li>
+                            <li><i data-feather="check-circle"></i> Priority queue</li>
+                            <li><i data-feather="check-circle"></i> Advanced tools</li>
+                        </ul>
+                        <a href="#" class="btn btn-primary">Choose Pro →</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+    <script src="assets/js/script.js"></script>
+    <script>feather.replace();</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add uncluttered navbar linking to Home, Study, Tools, Account, and Support
- create standalone pricing page with Free, Student, Standard, and Pro tiers
- add onboarding and account pages with upgrade CTA and usage meter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b07e3eadd883268ed3d8a32b629797