### PR TITLE
Adjust Pro plan checkout button

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
                             <li><i data-feather="check-circle"></i> Priority queue</li>
                             <li><i data-feather="check-circle"></i> Advanced tools</li>
                         </ul>
-                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606478" class="btn btn-primary">Start 14-Day Trial →</a>
+                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606478" class="btn btn-primary">Upgrade Now</a>
                     </div>
                 </div>
             </div>

--- a/pricing.html
+++ b/pricing.html
@@ -75,7 +75,7 @@
                             <li><i data-feather="check-circle"></i> Priority queue</li>
                             <li><i data-feather="check-circle"></i> Advanced tools</li>
                         </ul>
-                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606478" class="btn btn-primary">Start 14-Day Trial →</a>
+                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606478" class="btn btn-primary">Upgrade Now</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Show "Upgrade Now" on the Pro ($20/mo) plan checkout button
- Verify plan checkout links use the correct Lemon Squeezy IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b090ad511c83268e5628cff8e060cb