### PR TITLE
Clean up footer links and trial messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
             <div class="container">
                 <div class="cta-content animate-on-scroll">
                     <h2>Ready to Use Real AI Without the Overpriced Hype?</h2>
-                    <p>Try Prosper Spot free for 14 days — no credit card required.</p>
+                    <p>Try Prosper Spot free for 14 days. Cancel anytime.</p>
                     <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary btn-large">Start 14-Day Trial →</a>
                 </div>
             </div>
@@ -179,27 +179,10 @@
                 <div class="footer-col">
                     <h4>Product</h4><ul><li><a href="#features">Features</a></li><li><a href="#pricing">Pricing</a></li></ul>
                 </div>
-                <div class="footer-col">
-                    <h4>Company</h4>
-                    <ul>
-                        <li><a href="/about">About Us</a></li>
-                        <li><a href="/careers">Careers</a></li>
-                        <li><a href="/blog">Blog</a></li>
-                        <li><a href="/contact">Contact Us</a></li>
-                    </ul>
-                </div>
-                <div class="footer-col">
-                    <h4>Resources</h4>
-                    <ul>
-                        <li><a href="/docs">Documentation</a></li>
-                        <li><a href="/api">API Reference</a></li>
-                        <li><a href="/security">Security</a></li>
-                        <li><a href="https://status.prosperspot.com">System Status</a></li>
-                    </ul>
-                </div>
+                <!-- Removed placeholder Company and Resources links -->
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 Prosper Spot. All rights reserved.</p>
+                <p>&copy; 2025 Prosper Spot. All rights reserved.</p>
                 <div class="social-links"><a href="#" aria-label="Twitter"><i data-feather="twitter"></i></a><a href="#" aria-label="LinkedIn"><i data-feather="linkedin"></i></a><a href="#" aria-label="GitHub"><i data-feather="github"></i></a></div>
             </div>
         </div>

--- a/support.html
+++ b/support.html
@@ -74,7 +74,7 @@
                     </div>
                     <div class="faq-item">
                         <button class="faq-question"><span>How does the 14-day trial work?</span><i data-feather="chevron-down" class="faq-icon"></i></button>
-                        <div class="faq-answer"><p>Enjoy full access for 14 days — no credit card required.</p></div>
+                        <div class="faq-answer"><p>Enjoy full access for 14 days. Cancel anytime before your trial ends.</p></div>
                     </div>
                     <div class="faq-item">
                         <button class="faq-question"><span>Can I self-host Prosper Spot?</span><i data-feather="chevron-down" class="faq-icon"></i></button>
@@ -91,27 +91,10 @@
                 <div class="footer-col">
                     <h4>Product</h4><ul><li><a href="#features">Features</a></li><li><a href="#pricing">Pricing</a></li></ul>
                 </div>
-                <div class="footer-col">
-                    <h4>Company</h4>
-                    <ul>
-                        <li><a href="/about">About Us</a></li>
-                        <li><a href="/careers">Careers</a></li>
-                        <li><a href="/blog">Blog</a></li>
-                        <li><a href="/contact">Contact Us</a></li>
-                    </ul>
-                </div>
-                <div class="footer-col">
-                    <h4>Resources</h4>
-                    <ul>
-                        <li><a href="/docs">Documentation</a></li>
-                        <li><a href="/api">API Reference</a></li>
-                        <li><a href="/security">Security</a></li>
-                        <li><a href="https://status.prosperspot.com">System Status</a></li>
-                    </ul>
-                </div>
+                <!-- Removed placeholder Company and Resources links -->
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 Prosper Spot. All rights reserved.</p>
+                <p>&copy; 2025 Prosper Spot. All rights reserved.</p>
                 <div class="social-links"><a href="#" aria-label="Twitter"><i data-feather="twitter"></i></a><a href="#" aria-label="LinkedIn"><i data-feather="linkedin"></i></a><a href="#" aria-label="GitHub"><i data-feather="github"></i></a></div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove dead System Status link and placeholder footer links
- clarify 14-day trial messaging and drop "no credit card required" claim
- bump copyright year in footer to 2025

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09c5af0108326a30ae61463e2d677