### PR TITLE
Enhance support contact form with styling and email sending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ PORT=3000
 SUPABASE_URL=https://oreyljqmoojibfvrwvay.supabase.co
 SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9yZXlsanFtb29qaWJmdnJ3dmF5Iiwicm9sZSI6ImFub24iLCJleHAiOjE4MDAwMDAwMDB9.qrQEM7J4VfnWD3c91fhNwTE3vXcIzBgE4c3OJbGdv8E
 COOKIE_DOMAIN=.prosperspot.com
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-smtp-user
+SMTP_PASS=your-smtp-pass

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -18,6 +18,8 @@ html { scroll-behavior: smooth; }
 section { padding: 100px 0; }
 img { max-width: 100%; display: block; }
 a { color: var(--text-color); text-decoration: none; }
+.d-none { display: none !important; }
+.mt-3 { margin-top: 1rem; }
 
 /* --- Background Glow Effect --- */
 .background-glow { position: fixed; top: -50%; left: -50%; width: 200%; height: 200%; background: radial-gradient(circle, var(--glow-color) 0%, rgba(13, 12, 34, 0) 60%); animation: rotateGlow 20s linear infinite; z-index: -1; }
@@ -145,6 +147,10 @@ td i[data-feather="x-circle"] { color: var(--secondary-color); }
     display: flex;
     flex-direction: column;
     gap: 15px;
+    background-color: var(--card-bg);
+    padding: 25px;
+    border-radius: 12px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
 }
 
 .contact label {
@@ -153,11 +159,12 @@ td i[data-feather="x-circle"] { color: var(--secondary-color); }
 
 .contact input,
 .contact textarea {
-    background-color: var(--card-bg);
+    background-color: var(--bg-color);
     border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 12px 15px;
     color: var(--text-color);
+    transition: border-color 0.2s, box-shadow 0.2s;
 }
 
 .contact input:focus,
@@ -165,6 +172,21 @@ td i[data-feather="x-circle"] { color: var(--secondary-color); }
     outline: none;
     border-color: var(--secondary-color);
     box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
+}
+
+.contact .alert {
+    border-radius: 8px;
+    padding: 12px 15px;
+}
+
+.contact .alert-success {
+    background: #d1e7dd;
+    color: #0f5132;
+}
+
+.contact .alert-danger {
+    background: #f8d7da;
+    color: #842029;
 }
 
 /* --- FAQ Section --- */

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -16,15 +16,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
   form.addEventListener("submit", async function (e) {
     e.preventDefault();
-    const formData = new FormData(form);
+    const formData = Object.fromEntries(new FormData(form).entries());
     try {
       const endpoint = form.getAttribute("action");
       const response = await fetch(endpoint, {
         method: form.getAttribute("method") || "POST",
         headers: {
+          "Content-Type": "application/json",
           Accept: "application/json",
         },
-        body: formData,
+        body: JSON.stringify(formData),
       });
       if (response.ok) {
         showMessage("Thanks for contacting us!", "success");

--- a/server.js
+++ b/server.js
@@ -74,6 +74,25 @@ app.post('/request-invite', async (req, res) => {
   }
 });
 
+app.post('/contact', async (req, res) => {
+  const { name, email, message } = req.body || {};
+  if (!name || !email || !message) {
+    return res.status(400).json({ error: 'All fields are required' });
+  }
+  try {
+    await transporter.sendMail({
+      from: process.env.SMTP_USER,
+      to: 'support@prosperspot.com',
+      subject: `Support request from ${name}`,
+      text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
+    });
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to send contact email', err);
+    res.status(500).json({ error: 'Failed to send email' });
+  }
+});
+
 app.listen(PORT, () => {
   console.log(`Site + auth server running on http://127.0.0.1:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- Style support page form with card background, input transitions, and alert messages
- Send support form submissions to support@prosperspot.com via new /contact endpoint
- Document SMTP configuration variables

## Testing
- `node --check server.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09de385708326a892b7288b0d04ef