### PR TITLE
Revamp support page and update trial copy

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -14,7 +14,7 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: var(--font-family); background-color: var(--bg-color); color: var(--text-color); line-height: 1.6; overflow-x: hidden; }
 html { scroll-behavior: smooth; }
-.container { max-width: 1200px; margin: 0 auto; padding: 0 20px; }
+.container { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
 section { padding: 100px 0; }
 img { max-width: 100%; display: block; }
 a { color: var(--text-color); text-decoration: none; }
@@ -58,6 +58,7 @@ nav { display: flex; justify-content: space-between; align-items: center; }
 .section-header { text-align: center; margin-bottom: 60px; }
 .section-header h2 { font-size: 2.5rem; color: var(--heading-color); margin-bottom: 10px; }
 .section-header p { color: var(--secondary-color); font-size: 1.1rem; max-width: 600px; margin: 0 auto; }
+.trial-note { color: var(--secondary-color); font-size: 0.9rem; margin-top: 10px; }
 
 /* --- Features Section --- */
 .features-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 30px; align-items: stretch; }
@@ -140,64 +141,40 @@ td i[data-feather="x-circle"] { color: var(--secondary-color); }
 .pricing-card li { margin-bottom: 15px; display: flex; align-items: center; gap: 10px; }
 .pricing-card li i { color: #8A2BE2; width: 18px; height: 18px; }
 
-/* --- Contact Page --- */
-.contact form {
-    max-width: 600px;
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
-    background-color: var(--card-bg);
-    padding: 25px;
-    border-radius: 12px;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
-}
-
-.contact label {
-    font-weight: 500;
-}
-
-.contact input,
-.contact textarea {
-    background-color: var(--bg-color);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    padding: 12px 15px;
-    color: var(--text-color);
-    transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.contact input:focus,
-.contact textarea:focus {
-    outline: none;
-    border-color: var(--secondary-color);
-    box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
-}
-
-.contact .alert {
-    border-radius: 8px;
-    padding: 12px 15px;
-}
-
-.contact .alert-success {
-    background: #d1e7dd;
-    color: #0f5132;
-}
-
-.contact .alert-danger {
-    background: #f8d7da;
-    color: #842029;
-}
+/* --- Support Page --- */
+.support-grid { display: grid; grid-template-columns: 7fr 5fr; gap: 32px; }
+.support-card { background-color: var(--card-bg); padding: 32px; border-radius: 12px; box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1); border: 1px solid var(--border-color); }
+.support-subtitle { color: var(--secondary-color); margin-bottom: 24px; font-size: 0.9rem; }
+.support-card form { display: flex; flex-direction: column; }
+.field { margin-bottom: 16px; }
+.support-card label { font-size: 0.8rem; font-weight: 500; opacity: 0.65; margin-bottom: 6px; display: block; }
+.support-card input,
+.support-card textarea { width: 100%; background-color: var(--bg-color); border: 1px solid var(--border-color); border-radius: 12px; padding: 0 12px; height: 44px; color: var(--text-color); transition: border-color 0.2s, box-shadow 0.2s; }
+.support-card textarea { padding: 12px; min-height: 120px; resize: vertical; }
+.support-card input:focus,
+.support-card textarea:focus { outline: none; border-color: #8A2BE2; box-shadow: 0 0 0 2px rgba(138, 43, 226, 0.4); }
+.error { display: none; font-size: 0.75rem; color: #ff6b6b; margin-top: 4px; }
+.field.invalid .error { display: block; }
+#support-submit[disabled] { opacity: 0.5; cursor: not-allowed; }
+.form-response { margin-top: 16px; font-size: 0.875rem; }
+.form-response.success { color: #0f5132; }
+.form-response.error { color: #842029; }
+.hp-field { position: absolute; left: -10000px; width: 1px; height: 1px; overflow: hidden; }
+.btn-spinner { border: 2px solid transparent; border-top-color: #fff; border-right-color: #fff; border-radius: 50%; width: 16px; height: 16px; margin-right: 8px; animation: spin 1s linear infinite; display: inline-block; vertical-align: middle; }
+@keyframes spin { to { transform: rotate(360deg); } }
 
 /* --- FAQ Section --- */
-.faq-container { max-width: 800px; margin: 0 auto; }
+.faq-container { border-top: 1px solid var(--border-color); }
 .faq-item { border-bottom: 1px solid var(--border-color); }
-.faq-question { display: flex; justify-content: space-between; align-items: center; width: 100%; background: none; border: none; padding: 20px 0; font-size: 1.2rem; color: var(--heading-color); cursor: pointer; text-align: left; }
+.faq-question { display: flex; justify-content: space-between; align-items: center; width: 100%; background: none; border: none; padding: 16px 0; font-size: 1.125rem; font-weight: 600; color: var(--heading-color); cursor: pointer; text-align: left; }
 .faq-question span { flex: 1; }
-.faq-icon { transition: transform 0.3s ease; }
-.faq-item.active .faq-icon { transform: rotate(180deg); }
-.faq-answer { max-height: 0; overflow: hidden; transition: max-height 0.3s ease-in-out; }
-.faq-answer p { padding: 0 0 20px 0; color: var(--secondary-color); }
+.faq-icon { transition: transform 0.2s ease; }
+.faq-item.active .faq-icon { transform: rotate(90deg); }
+.faq-answer { max-height: 0; opacity: 0; overflow: hidden; transition: max-height 0.2s ease, opacity 0.2s ease; }
+.faq-item.active .faq-answer { opacity: 1; }
+.faq-answer p { padding: 8px 0 16px 0; color: var(--secondary-color); }
+@media (max-width: 768px) { .support-grid { grid-template-columns: 1fr; gap: 24px; } }
+@media (prefers-reduced-motion: reduce) { .faq-answer { transition: none; } .btn-spinner { animation: none; } }
 
 /* --- Final CTA --- */
 .final-cta { padding: 100px 0; }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -56,23 +56,98 @@ document.addEventListener('DOMContentLoaded', () => {
         const answer = item.querySelector('.faq-answer');
 
         question.addEventListener('click', () => {
-            const isActive = item.classList.contains('active');
-
-            // Optional: Close all other items
-            // faqItems.forEach(i => {
-            //     i.classList.remove('active');
-            //     i.querySelector('.faq-answer').style.maxHeight = 0;
-            // });
-
-            if (isActive) {
-                item.classList.remove('active');
-                answer.style.maxHeight = 0;
-            } else {
-                item.classList.add('active');
+            const expanded = question.getAttribute('aria-expanded') === 'true';
+            question.setAttribute('aria-expanded', String(!expanded));
+            item.classList.toggle('active', !expanded);
+            if (!expanded) {
                 answer.style.maxHeight = answer.scrollHeight + 'px';
+                answer.style.opacity = 1;
+            } else {
+                answer.style.maxHeight = 0;
+                answer.style.opacity = 0;
+            }
+            if (question.dataset.key) {
+                window.dataLayer?.push({ event: 'faq_toggle', question: question.dataset.key });
             }
         });
     });
+
+    // Support Form
+    const supportForm = document.getElementById('support-form');
+    if (supportForm) {
+        const fields = {
+            name: supportForm.querySelector('#support-name'),
+            email: supportForm.querySelector('#support-email'),
+            message: supportForm.querySelector('#support-message'),
+            honey: supportForm.querySelector('#support-company')
+        };
+        const submitBtn = document.getElementById('support-submit');
+        const responseEl = document.getElementById('support-response');
+
+        const validators = {
+            name: v => v.trim().length > 0,
+            email: v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
+            message: v => v.trim().length > 0
+        };
+
+        function validateField(key) {
+            const field = fields[key];
+            const valid = validators[key](field.value);
+            field.parentElement.classList.toggle('invalid', !valid);
+            return valid;
+        }
+
+        function checkForm() {
+            const valid = ['name', 'email', 'message'].every(validateField);
+            submitBtn.disabled = !valid;
+            return valid;
+        }
+
+        ['name', 'email', 'message'].forEach(k => {
+            fields[k].addEventListener('input', () => { validateField(k); checkForm(); });
+            fields[k].addEventListener('blur', () => validateField(k));
+        });
+
+        supportForm.addEventListener('submit', async e => {
+            e.preventDefault();
+            if (fields.honey.value) return; // honeypot
+            if (!checkForm()) return;
+
+            submitBtn.disabled = true;
+            submitBtn.innerHTML = '<span class="btn-spinner"></span>Sending…';
+            responseEl.textContent = '';
+            responseEl.className = 'form-response';
+
+            try {
+                const res = await fetch(supportForm.action, {
+                    method: supportForm.method,
+                    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+                    body: JSON.stringify({
+                        name: fields.name.value.trim(),
+                        email: fields.email.value.trim(),
+                        message: fields.message.value.trim()
+                    })
+                });
+                if (!res.ok) throw new Error('Request failed');
+                submitBtn.innerHTML = '✓';
+                responseEl.textContent = "Message sent. We'll get back to you soon.";
+                responseEl.classList.add('success');
+                window.dataLayer?.push({ event: 'support_submit_success' });
+                supportForm.reset();
+                checkForm();
+            } catch (err) {
+                submitBtn.innerHTML = '!';
+                responseEl.textContent = 'Something went wrong. Please try again.';
+                responseEl.classList.add('error');
+                window.dataLayer?.push({ event: 'support_submit_error' });
+            } finally {
+                setTimeout(() => {
+                    submitBtn.innerHTML = 'Send';
+                    checkForm();
+                }, 2000);
+            }
+        });
+    }
 
     // Feather Icons
     if (typeof feather !== 'undefined') {

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                     <p class="animate-on-scroll">Prosper Spot gives you serious AI power — without the bloated price tag.</p>
                     <p class="animate-on-scroll">Study sharper. Write faster. Think deeper. All without paying $20/month just to ask questions.</p>
                     <div class="hero-buttons animate-on-scroll">
-                        <a href="#pricing" class="btn btn-primary btn-large">🔓 Start 14-Day Trial</a>
+                        <a href="#pricing" class="btn btn-primary btn-large">🔓 Start 14-Day Free Trial</a>
                         <a href="#" class="btn btn-secondary btn-large">🧠 Learn More</a>
                     </div>
                 </div>
@@ -104,7 +104,7 @@
                             <li><i data-feather="check-circle"></i> Faster answers</li>
                             <li><i data-feather="check-circle"></i> Larger context</li>
                         </ul>
-                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606476" class="btn btn-primary">Start 14-Day Trial →</a>
+                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606476" class="btn btn-primary">Start 14-Day Free Trial →</a>
                     </div>
                     <div class="pricing-card popular animate-on-scroll">
                         <div class="popular-badge">Most Popular</div>
@@ -116,7 +116,7 @@
                             <li><i data-feather="check-circle"></i> Larger context</li>
                             <li><i data-feather="check-circle"></i> Priority queue</li>
                         </ul>
-                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary">Start 14-Day Trial →</a>
+                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary">Start 14-Day Free Trial →</a>
                     </div>
                     <div class="pricing-card animate-on-scroll">
                         <h3>Pro</h3>
@@ -165,8 +165,8 @@
             <div class="container">
                 <div class="cta-content animate-on-scroll">
                     <h2>Ready to Use Real AI Without the Overpriced Hype?</h2>
-                    <p>Try Prosper Spot free for 14 days. Cancel anytime.</p>
-                    <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary btn-large">Start 14-Day Trial →</a>
+                    <p>Try Prosper Spot free for 14 days. Cancel anytime before day 14.</p>
+                    <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary btn-large">Start 14-Day Free Trial →</a>
                 </div>
             </div>
         </section>

--- a/onboarding.html
+++ b/onboarding.html
@@ -19,7 +19,7 @@
                 <div class="hero-content">
                     <h1>Pick your study buddy, tools, and limits</h1>
                     <p>You're all set! Customize how you work with AI and get more when you upgrade.</p>
-                    <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary btn-large">Start 14-Day Trial →</a>
+                    <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary btn-large">Start 14-Day Free Trial →</a>
                 </div>
             </div>
         </section>

--- a/pricing.html
+++ b/pricing.html
@@ -41,6 +41,7 @@
                 <div class="section-header">
                     <h1>Choose Your Plan</h1>
                     <p>No model names, just benefits.</p>
+                    <p class="trial-note">Start 14-Day Free Trial. Cancel anytime before day 14.</p>
                 </div>
                 <div class="pricing-grid">
                     <div class="pricing-card">
@@ -51,7 +52,7 @@
                             <li><i data-feather="check-circle"></i> Faster answers</li>
                             <li><i data-feather="check-circle"></i> Larger context</li>
                         </ul>
-                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606476" class="btn btn-primary">Start 14-Day Trial →</a>
+                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606476" class="btn btn-primary">Start 14-Day Free Trial →</a>
                     </div>
                     <div class="pricing-card popular">
                         <div class="popular-badge">Most Popular</div>
@@ -63,7 +64,7 @@
                             <li><i data-feather="check-circle"></i> Larger context</li>
                             <li><i data-feather="check-circle"></i> Priority queue</li>
                         </ul>
-                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary">Start 14-Day Trial →</a>
+                        <a href="https://prosperspot.lemonsqueezy.com/checkout/buy/606477" class="btn btn-primary">Start 14-Day Free Trial →</a>
                     </div>
                     <div class="pricing-card">
                         <h3>Pro</h3>

--- a/server.js
+++ b/server.js
@@ -14,6 +14,9 @@ app.use(express.static(path.join(__dirname)));
 // ---- Health ----
 app.get('/healthz', (req, res) => res.json({ ok: true }));
 
+// Legacy status page
+app.get('/status', (req, res) => res.redirect(301, '/'));
+
 
 // ---- Lemon Squeezy webhook ----
 // IMPORTANT: raw body ONLY for this one route.

--- a/support.html
+++ b/support.html
@@ -36,49 +36,60 @@
         </div>
     </header>
     <main>
-        <section class="contact">
+        <section class="support">
             <div class="container">
-                <div class="section-header">
-                    <h1>Contact Support</h1>
-                </div>
-                <form id="contact-form" action="/contact" method="POST">
-                    <label for="name">Name</label>
-                    <input type="text" id="name" name="name" required>
-                    <label for="email">Email</label>
-                    <input type="email" id="email" name="email" required>
-                    <label for="message">Message</label>
-                    <textarea id="message" name="message" rows="5" required></textarea>
-                    <button type="submit" class="btn btn-primary">Send</button>
-                    <div id="form-message" class="d-none"></div>
-                </form>
-            </div>
-        </section>
-
-        <section class="faq">
-            <div class="container">
-                <div class="section-header">
-                    <h2 class="animate-on-scroll">❓ FAQ</h2>
-                </div>
-                <div class="faq-container">
-                    <div class="faq-item">
-                        <button class="faq-question"><span>Can I switch plans later?</span><i data-feather="chevron-down" class="faq-icon"></i></button>
-                        <div class="faq-answer"><p>Yes — upgrade, downgrade, or cancel anytime.</p></div>
+                <div class="support-grid">
+                    <div class="support-card">
+                        <h2>Contact Support</h2>
+                        <p class="support-subtitle">We usually reply within a business day.</p>
+                        <form id="support-form" action="/contact" method="POST" novalidate>
+                            <div class="field">
+                                <label for="support-name">Name</label>
+                                <input type="text" id="support-name" name="name" required>
+                                <div class="error">Name is required.</div>
+                            </div>
+                            <div class="field">
+                                <label for="support-email">Email</label>
+                                <input type="email" id="support-email" name="email" required>
+                                <div class="error">Valid email required.</div>
+                            </div>
+                            <div class="field">
+                                <label for="support-message">Message</label>
+                                <textarea id="support-message" name="message" required></textarea>
+                                <div class="error">Message is required.</div>
+                            </div>
+                            <div class="field hp-field">
+                                <label for="support-company">Company</label>
+                                <input type="text" id="support-company" name="company" tabindex="-1" autocomplete="off">
+                            </div>
+                            <button type="submit" class="btn btn-primary" id="support-submit" disabled>Send</button>
+                            <div id="support-response" class="form-response" aria-live="polite"></div>
+                        </form>
                     </div>
-                    <div class="faq-item">
-                        <button class="faq-question"><span>How is Prosper Spot different from ChatGPT?</span><i data-feather="chevron-down" class="faq-icon"></i></button>
-                        <div class="faq-answer"><p>We’re focused on real-world tools, not just chat. Plus, we’re cheaper, faster, and more customizable.</p></div>
-                    </div>
-                    <div class="faq-item">
-                        <button class="faq-question"><span>Do I need to install anything?</span><i data-feather="chevron-down" class="faq-icon"></i></button>
-                        <div class="faq-answer"><p>Nope. Use it in your browser — or self-host if you prefer.</p></div>
-                    </div>
-                    <div class="faq-item">
-                        <button class="faq-question"><span>How does the 14-day trial work?</span><i data-feather="chevron-down" class="faq-icon"></i></button>
-                        <div class="faq-answer"><p>Enjoy full access for 14 days. Cancel anytime before your trial ends.</p></div>
-                    </div>
-                    <div class="faq-item">
-                        <button class="faq-question"><span>Can I self-host Prosper Spot?</span><i data-feather="chevron-down" class="faq-icon"></i></button>
-                        <div class="faq-answer"><p>Yes! We support open models and private deployments.</p></div>
+                    <div class="faq-col">
+                        <h2 class="faq-heading">FAQ</h2>
+                        <div class="faq-container">
+                            <div class="faq-item">
+                                <button class="faq-question" aria-expanded="false" aria-controls="faq1" data-key="switch_plans"><span>Can I switch plans later?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
+                                <div class="faq-answer" id="faq1" role="region"><p>Yes — upgrade, downgrade, or cancel anytime.</p></div>
+                            </div>
+                            <div class="faq-item">
+                                <button class="faq-question" aria-expanded="false" aria-controls="faq2" data-key="difference"><span>How is Prosper Spot different from ChatGPT?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
+                                <div class="faq-answer" id="faq2" role="region"><p>We’re focused on real-world tools, not just chat. Plus, we’re cheaper, faster, and more customizable.</p></div>
+                            </div>
+                            <div class="faq-item">
+                                <button class="faq-question" aria-expanded="false" aria-controls="faq3" data-key="install"><span>Do I need to install anything?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
+                                <div class="faq-answer" id="faq3" role="region"><p>Nope. Use it in your browser — or self-host if you prefer.</p></div>
+                            </div>
+                            <div class="faq-item">
+                                <button class="faq-question" aria-expanded="false" aria-controls="faq4" data-key="trial"><span>How does the 14-day trial work?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
+                                <div class="faq-answer" id="faq4" role="region"><p>Enjoy full access for 14 days. Cancel anytime before your trial ends.</p></div>
+                            </div>
+                            <div class="faq-item">
+                                <button class="faq-question" aria-expanded="false" aria-controls="faq5" data-key="self_host"><span>Can I self-host Prosper Spot?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
+                                <div class="faq-answer" id="faq5" role="region"><p>Yes! We support open models and private deployments.</p></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -100,7 +111,6 @@
         </div>
     </footer>
     <script src="assets/js/script.js"></script>
-    <script src="assets/js/contact.js"></script>
     <script>
         feather.replace();
     </script>


### PR DESCRIPTION
## Summary
- Rebuild support page with 2-column layout, polished contact form, and animated accessible FAQ
- Centralize container sizing and add form/accordion scripts with analytics hooks
- Refresh trial messaging sitewide and route legacy status page to home

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae115f3483269979a16fd1d23fbb