### PR TITLE
feat: add auth-aware navigation

### DIFF
--- a/account.html
+++ b/account.html
@@ -22,12 +22,14 @@
                 </a>
                 <ul class="nav-links">
                     <li><a href="index.html">Home</a></li>
-                    <li><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
+                    <li class="nav-open-app d-none"><a href="https://app.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
-                    <a href="auth.html" class="btn btn-secondary">Log In</a>
-                    <a href="index.html#pricing" class="btn btn-primary">Upgrade</a>
+                    <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
+                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Open Menu">
                     <i data-feather="menu"></i>
@@ -49,6 +51,9 @@
             </div>
         </section>
     </main>
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="assets/js/supabaseEnv.js"></script>
+    <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/script.js"></script>
     <script>feather.replace();</script>
 </body>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -10,6 +10,57 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    // Auth-aware Navigation
+    const loginLink = document.querySelector('.nav-login');
+    const logoutLink = document.querySelector('.nav-logout');
+    const accountLink = document.querySelector('.nav-account');
+    const openAppLink = document.querySelector('.nav-open-app');
+    const upgradeLinks = document.querySelectorAll('.nav-upgrade');
+    let currentSession = null;
+
+    const setRedirect = () => {
+        if (loginLink) {
+            const current = window.location.pathname + window.location.search;
+            loginLink.href = `auth.html?redirect=${encodeURIComponent(current)}`;
+        }
+    };
+
+    setRedirect();
+
+    function updateNav(session) {
+        currentSession = session;
+        if (session) {
+            loginLink?.classList.add('d-none');
+            accountLink?.classList.remove('d-none');
+            logoutLink?.classList.remove('d-none');
+            openAppLink?.classList.remove('d-none');
+        } else {
+            loginLink?.classList.remove('d-none');
+            accountLink?.classList.add('d-none');
+            logoutLink?.classList.add('d-none');
+            openAppLink?.classList.add('d-none');
+        }
+    }
+
+    if (window.supabaseClient) {
+        window.supabaseClient.auth.getSession().then(({ data }) => {
+            updateNav(data.session);
+        });
+        window.supabaseClient.auth.onAuthStateChange((_event, session) => {
+            updateNav(session);
+        });
+    }
+
+    upgradeLinks.forEach(link => {
+        link.addEventListener('click', (e) => {
+            if (!currentSession) {
+                e.preventDefault();
+                const dest = link.getAttribute('href') || '/pricing.html';
+                window.location.href = `auth.html?redirect=${encodeURIComponent(dest)}`;
+            }
+        });
+    });
+
     // On-Scroll Animations
     const observer = new IntersectionObserver((entries) => {
         entries.forEach(entry => {

--- a/index.html
+++ b/index.html
@@ -29,12 +29,14 @@
                 </a>
                 <ul class="nav-links">
                     <li><a href="index.html">Home</a></li>
-                    <li><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
+                    <li class="nav-open-app d-none"><a href="https://app.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
-                    <a href="auth.html" class="btn btn-secondary">Log In</a>
-                    <a href="#pricing" class="btn btn-primary">Upgrade</a>
+                    <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
+                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Open Menu">
                     <i data-feather="menu"></i>
@@ -188,6 +190,9 @@
         </div>
     </footer>
 
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="assets/js/supabaseEnv.js"></script>
+    <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/script.js"></script>
     <script>
         feather.replace();

--- a/pricing.html
+++ b/pricing.html
@@ -22,12 +22,14 @@
                 </a>
                 <ul class="nav-links">
                     <li><a href="index.html">Home</a></li>
-                    <li><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
+                    <li class="nav-open-app d-none"><a href="https://app.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
-                    <a href="auth.html" class="btn btn-secondary">Log In</a>
-                    <a href="index.html#pricing" class="btn btn-primary">Upgrade</a>
+                    <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
+                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Open Menu">
                     <i data-feather="menu"></i>
@@ -82,6 +84,9 @@
             </div>
         </section>
     </main>
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="assets/js/supabaseEnv.js"></script>
+    <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/script.js"></script>
     <script>feather.replace();</script>
 </body>

--- a/support.html
+++ b/support.html
@@ -22,12 +22,14 @@
                 </a>
                 <ul class="nav-links">
                     <li><a href="index.html">Home</a></li>
-                    <li><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
+                    <li class="nav-open-app d-none"><a href="https://app.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
-                    <a href="auth.html" class="btn btn-secondary">Log In</a>
-                    <a href="index.html#pricing" class="btn btn-primary">Upgrade</a>
+                    <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
+                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Open Menu">
                     <i data-feather="menu"></i>
@@ -110,6 +112,9 @@
             </div>
         </div>
     </footer>
+    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <script src="assets/js/supabaseEnv.js"></script>
+    <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/script.js"></script>
     <script>
         feather.replace();


### PR DESCRIPTION
## Summary
- show account, app, and logout links only after Supabase session is active
- redirect unauthenticated upgrade clicks through login preserving destination

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b52c831c832698ef27fcb2044501