### PR TITLE
Point Open App to chat.prosperspot.com and invert tagline text

### DIFF
--- a/account.html
+++ b/account.html
@@ -24,7 +24,7 @@
                     <li><a href="index.html">Home</a></li>
                     <li class="nav-account d-none"><a href="account.html" aria-current="page">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://app.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
@@ -56,7 +56,7 @@
     <footer>
         <div class="container">
             <div class="footer-grid">
-                <div class="footer-col"><a href="#" class="logo"><img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="24" /><span>Prosper Spot</span></a><p>Smarter AI. Built for Real Work.</p></div>
+                <div class="footer-col"><a href="#" class="logo"><img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="24" /><span>Prosper Spot</span></a><p class="invert-text">Smarter AI. Built for Real Work.</p></div>
                 <div class="footer-col">
                     <h4>Product</h4><ul><li><a href="index.html#features">Features</a></li><li><a href="index.html#pricing">Pricing</a></li></ul>
                 </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,6 +20,7 @@ img { max-width: 100%; display: block; }
 a { color: var(--text-color); text-decoration: none; }
 .d-none { display: none !important; }
 .mt-3 { margin-top: 1rem; }
+.invert-text { filter: invert(1); }
 
 /* --- Background Glow Effect --- */
 .background-glow { position: fixed; top: -50%; left: -50%; width: 200%; height: 200%; background: radial-gradient(circle, var(--glow-color) 0%, rgba(13, 12, 34, 0) 60%); animation: rotateGlow 20s linear infinite; z-index: -1; }

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
                     <li><a href="index.html" aria-current="page">Home</a></li>
                     <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://app.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
@@ -50,7 +50,7 @@
         <section class="hero">
             <div class="container">
                 <div class="hero-content">
-                    <h1 class="animate-on-scroll">Smarter AI. Built for Real Work.</h1>
+                    <h1 class="animate-on-scroll invert-text">Smarter AI. Built for Real Work.</h1>
                     <p class="hero-tagline animate-on-scroll">Your Affordable AI Co‑Pilot for Study, Research, and Everything in Between</p>
                     <p class="animate-on-scroll">Prosper Spot gives you serious AI power — without the bloated price tag.</p>
                     <p class="animate-on-scroll">Study sharper. Write faster. Think deeper. All without paying $20/month just to ask questions.</p>
@@ -177,7 +177,7 @@
     <footer>
         <div class="container">
             <div class="footer-grid">
-                <div class="footer-col"><a href="#" class="logo"><img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="24" /><span>Prosper Spot</span></a><p>Smarter AI. Built for Real Work.</p></div>
+                <div class="footer-col"><a href="#" class="logo"><img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="24" /><span>Prosper Spot</span></a><p class="invert-text">Smarter AI. Built for Real Work.</p></div>
                 <div class="footer-col">
                     <h4>Product</h4><ul><li><a href="#features">Features</a></li><li><a href="#pricing">Pricing</a></li></ul>
                 </div>

--- a/pricing.html
+++ b/pricing.html
@@ -24,7 +24,7 @@
                     <li><a href="index.html">Home</a></li>
                     <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://app.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
@@ -87,7 +87,7 @@
     <footer>
         <div class="container">
             <div class="footer-grid">
-                <div class="footer-col"><a href="#" class="logo"><img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="24" /><span>Prosper Spot</span></a><p>Smarter AI. Built for Real Work.</p></div>
+                <div class="footer-col"><a href="#" class="logo"><img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="24" /><span>Prosper Spot</span></a><p class="invert-text">Smarter AI. Built for Real Work.</p></div>
                 <div class="footer-col">
                     <h4>Product</h4><ul><li><a href="index.html#features">Features</a></li><li><a href="index.html#pricing">Pricing</a></li></ul>
                 </div>

--- a/support.html
+++ b/support.html
@@ -24,7 +24,7 @@
                     <li><a href="index.html">Home</a></li>
                     <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html" aria-current="page">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://app.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
@@ -100,7 +100,7 @@
     <footer>
         <div class="container">
             <div class="footer-grid">
-                <div class="footer-col"><a href="#" class="logo"><img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="24" /><span>Prosper Spot</span></a><p>Smarter AI. Built for Real Work.</p></div>
+                <div class="footer-col"><a href="#" class="logo"><img src="/assets/img/logo/logo5r.png" alt="Prosper Spot logo" height="24" /><span>Prosper Spot</span></a><p class="invert-text">Smarter AI. Built for Real Work.</p></div>
                 <div class="footer-col">
                     <h4>Product</h4><ul><li><a href="index.html#features">Features</a></li><li><a href="index.html#pricing">Pricing</a></li></ul>
                 </div>


### PR DESCRIPTION
## Summary
- Route all "Open App" navigation links to chat.prosperspot.com
- Add CSS helper class to invert colors on the "Smarter AI. Built for Real Work." tagline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0dfc0d98c83269dd1b7a7da114849