### PR TITLE
Revise marketing copy and remove self-hosting references

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,13 +66,13 @@
         <section id="features" class="features">
             <div class="container">
                 <div class="section-header">
-                    <h2 class="animate-on-scroll">Not Just a Chatbot. A Platform That Works.</h2>
-                    <p class="animate-on-scroll">Prosper Spot is a complete AI workspace — built for students, creators, thinkers, and doers.</p>
+                    <h2 class="animate-on-scroll">More than chat. A real AI workspace.</h2>
+                    <p class="animate-on-scroll">An AI workspace for study, writing, research, and getting sh*t done.</p>
                 </div>
                 <div class="features-grid">
-                    <div class="feature-card animate-on-scroll"><div class="icon-wrapper"><i data-feather="brain"></i></div><h3>Tuned AI Assistants</h3><p>Smart, purpose-built AIs for studying, writing, brainstorming, researching, and more.</p></div>
-                    <div class="feature-card animate-on-scroll"><div class="icon-wrapper"><i data-feather="dollar-sign"></i></div><h3>Half the Price of the Usual Suspects</h3><p>Just $10/month. Students? $5. No tokens. No surprise bills. Just access.</p></div>
-                    <div class="feature-card animate-on-scroll"><div class="icon-wrapper"><i data-feather="settings"></i></div><h3>Host It Yourself, If You Want</h3><p>Prefer control? We support open models, custom workflows, and self-hosted installs.</p></div>
+                    <div class="feature-card animate-on-scroll"><div class="icon-wrapper"><i data-feather="brain"></i></div><h3>Tuned assistants</h3><p>Tuned assistants for studying, writing, brainstorming, and research—no fluff, just results.</p></div>
+                    <div class="feature-card animate-on-scroll"><div class="icon-wrapper"><i data-feather="dollar-sign"></i></div><h3>Half the price. All the power.</h3><p>$10/mo, students $5. No surprise meters. 14-day free trial.</p></div>
+                    <div class="feature-card animate-on-scroll"><div class="icon-wrapper"><i data-feather="settings"></i></div><h3>Private by design</h3><p>Your chats stay yours. We don’t resell your data. Built on open models for transparency.</p></div>
                 </div>
             </div>
         </section>

--- a/support.html
+++ b/support.html
@@ -81,15 +81,15 @@
                             </div>
                             <div class="faq-item">
                                 <button class="faq-question" aria-expanded="false" aria-controls="faq3" data-key="install"><span>Do I need to install anything?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
-                                <div class="faq-answer" id="faq3" role="region"><p>Nope. Use it in your browser — or self-host if you prefer.</p></div>
+                                <div class="faq-answer" id="faq3" role="region"><p>Nope. Use it in your browser—nothing to install.</p></div>
                             </div>
                             <div class="faq-item">
                                 <button class="faq-question" aria-expanded="false" aria-controls="faq4" data-key="trial"><span>How does the 14-day trial work?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
                                 <div class="faq-answer" id="faq4" role="region"><p>Enjoy full access for 14 days. Cancel anytime before your trial ends.</p></div>
                             </div>
                             <div class="faq-item">
-                                <button class="faq-question" aria-expanded="false" aria-controls="faq5" data-key="self_host"><span>Can I self-host Prosper Spot?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
-                                <div class="faq-answer" id="faq5" role="region"><p>Yes! We support open models and private deployments.</p></div>
+                                <button class="faq-question" aria-expanded="false" aria-controls="faq5" data-key="privacy"><span>Is my data private?</span><i data-feather="chevron-right" class="faq-icon"></i></button>
+                                <div class="faq-answer" id="faq5" role="region"><p>Your chats stay yours. We don’t resell your data. Built on open models for transparency.</p></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Refresh hero and feature copy to highlight AI workspace and privacy-first messaging
- Update FAQ entries to drop self-hosting and emphasize data privacy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0e497e248832695f9ed7e405c0940