### PR TITLE
Hide logged-in nav items until session loads

### DIFF
--- a/account.html
+++ b/account.html
@@ -22,14 +22,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html">Home</a></li>
-                    <li class="nav-account d-none"><a href="account.html" aria-current="page">Account</a></li>
+                    <li class="nav-account d-none" hidden><a href="account.html" aria-current="page">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>

--- a/auth.html
+++ b/auth.html
@@ -22,14 +22,14 @@
         </a>
         <ul class="nav-links" id="nav-menu">
           <li><a href="index.html">Home</a></li>
-          <li class="nav-account d-none"><a href="account.html">Account</a></li>
+          <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
           <li><a href="support.html">Support</a></li>
-          <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
+          <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
         </ul>
         <div class="nav-buttons">
           <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
           <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-          <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
+          <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
         </div>
         <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
           <i data-feather="menu"></i>

--- a/index.html
+++ b/index.html
@@ -29,14 +29,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html" aria-current="page">Home</a></li>
-                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>
@@ -56,7 +56,7 @@
                     <p class="animate-on-scroll">Study sharper. Write faster. Think deeper. All without paying $20/month just to ask questions.</p>
                     <div class="hero-buttons animate-on-scroll">
                         <a href="#pricing" class="btn btn-primary btn-large">🔓 Start 14-Day Free Trial</a>
-                        <a href="#" class="btn btn-secondary btn-large">🧠 Learn More</a>
+                        <a href="#features" class="btn btn-secondary btn-large">🧠 Learn More</a>
                     </div>
                 </div>
             </div>
@@ -82,7 +82,7 @@
             <div class="container">
                 <div class="section-header">
                     <h2 class="animate-on-scroll">See Prosper Spot in Action</h2>
-                    <p class="animate-on-scroll">Watch it solve real problems, generate real answers, and adapt to your needs — in real time.</p>
+                    <p class="animate-on-scroll">See how it solves real problems, generates real answers, and adapts to your needs — in real time.</p>
                 </div>
                 <div class="showcase-wrapper animate-on-scroll">
                     <img src="/assets/img/demo.gif" alt="Prosper Spot demo" class="showcase-video" />

--- a/logout.html
+++ b/logout.html
@@ -22,14 +22,14 @@
         </a>
         <ul class="nav-links" id="nav-menu">
           <li><a href="index.html">Home</a></li>
-          <li class="nav-account d-none"><a href="account.html">Account</a></li>
+          <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
           <li><a href="support.html">Support</a></li>
-          <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
+          <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
         </ul>
         <div class="nav-buttons">
           <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
           <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-          <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
+          <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
         </div>
         <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
           <i data-feather="menu"></i>

--- a/onboarding.html
+++ b/onboarding.html
@@ -22,14 +22,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html">Home</a></li>
-                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>

--- a/pricing.html
+++ b/pricing.html
@@ -22,14 +22,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html">Home</a></li>
-                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
                 </div>
                     <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>

--- a/support.html
+++ b/support.html
@@ -22,14 +22,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html">Home</a></li>
-                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
                     <li><a href="support.html" aria-current="page">Support</a></li>
-                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>


### PR DESCRIPTION
## Summary
- Default Account, Logout, and Open App links to hidden to prevent nav flash
- Link home hero "Learn More" CTA to Features and refine demo copy

## Testing
- `npm test`
- `for id in 606476 606477 606478; do echo "--- $id"; curl -I -s https://prosperspot.lemonsqueezy.com/checkout/buy/$id | head -n 2; done`

------
https://chatgpt.com/codex/tasks/task_e_68b0e729e30c8326a0e4f5028e7733e9