### PR TITLE
Persist nav auth state and simplify header defaults

### DIFF
--- a/account.html
+++ b/account.html
@@ -22,14 +22,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html">Home</a></li>
-                    <li class="nav-account d-none" hidden><a href="account.html" aria-current="page">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html" aria-current="page">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,3 +1,60 @@
+const loginLink = document.querySelector('.nav-login');
+const logoutLink = document.querySelector('.nav-logout');
+const accountLink = document.querySelector('.nav-account');
+const openAppLink = document.querySelector('.nav-open-app');
+const upgradeLinks = document.querySelectorAll('.nav-upgrade');
+let currentSession = null;
+let wasLoggedIn = false;
+
+if (localStorage.getItem('ps_logged_in') === 'true') {
+    loginLink?.classList.add('d-none');
+    accountLink?.classList.remove('d-none');
+    logoutLink?.classList.remove('d-none');
+    openAppLink?.classList.remove('d-none');
+    wasLoggedIn = true;
+}
+
+const setRedirect = () => {
+    if (loginLink) {
+        const current = window.location.pathname + window.location.search;
+        loginLink.href = `auth.html?redirect=${encodeURIComponent(current)}`;
+    }
+};
+
+setRedirect();
+
+function showLogoutBanner() {
+    if (document.getElementById('session-expired')) return;
+    const banner = document.createElement('div');
+    banner.id = 'session-expired';
+    banner.className = 'session-expired';
+    const redirect = window.location.pathname + window.location.search;
+    banner.innerHTML = `Logged out due to inactivity — <a href="auth.html?redirect=${encodeURIComponent(redirect)}">Log in again</a>`;
+    document.body.prepend(banner);
+}
+
+function updateNav(session) {
+    currentSession = session;
+    if (session) {
+        loginLink?.classList.add('d-none');
+        accountLink?.classList.remove('d-none');
+        logoutLink?.classList.remove('d-none');
+        openAppLink?.classList.remove('d-none');
+        localStorage.setItem('ps_logged_in', 'true');
+        document.getElementById('session-expired')?.remove();
+        wasLoggedIn = true;
+    } else {
+        loginLink?.classList.remove('d-none');
+        accountLink?.classList.add('d-none');
+        logoutLink?.classList.add('d-none');
+        openAppLink?.classList.add('d-none');
+        localStorage.setItem('ps_logged_in', 'false');
+        if (wasLoggedIn) showLogoutBanner();
+        wasLoggedIn = false;
+        setRedirect();
+    }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
 
     // Mobile Navigation Toggle with accessibility
@@ -39,54 +96,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 menuToggle.focus();
             }
         });
-    }
-
-    // Auth-aware Navigation
-    const loginLink = document.querySelector('.nav-login');
-    const logoutLink = document.querySelector('.nav-logout');
-    const accountLink = document.querySelector('.nav-account');
-    const openAppLink = document.querySelector('.nav-open-app');
-    const upgradeLinks = document.querySelectorAll('.nav-upgrade');
-    let currentSession = null;
-    let wasLoggedIn = false;
-
-    const setRedirect = () => {
-        if (loginLink) {
-            const current = window.location.pathname + window.location.search;
-            loginLink.href = `auth.html?redirect=${encodeURIComponent(current)}`;
-        }
-    };
-
-    setRedirect();
-
-    function showLogoutBanner() {
-        if (document.getElementById('session-expired')) return;
-        const banner = document.createElement('div');
-        banner.id = 'session-expired';
-        banner.className = 'session-expired';
-        const redirect = window.location.pathname + window.location.search;
-        banner.innerHTML = `Logged out due to inactivity — <a href="auth.html?redirect=${encodeURIComponent(redirect)}">Log in again</a>`;
-        document.body.prepend(banner);
-    }
-
-    function updateNav(session) {
-        currentSession = session;
-        if (session) {
-            loginLink?.classList.add('d-none');
-            accountLink?.classList.remove('d-none');
-            logoutLink?.classList.remove('d-none');
-            openAppLink?.classList.remove('d-none');
-            document.getElementById('session-expired')?.remove();
-            wasLoggedIn = true;
-        } else {
-            loginLink?.classList.remove('d-none');
-            accountLink?.classList.add('d-none');
-            logoutLink?.classList.add('d-none');
-            openAppLink?.classList.add('d-none');
-            if (wasLoggedIn) showLogoutBanner();
-            wasLoggedIn = false;
-            setRedirect();
-        }
     }
 
     if (window.supabaseClient) {

--- a/auth.html
+++ b/auth.html
@@ -22,14 +22,14 @@
         </a>
         <ul class="nav-links" id="nav-menu">
           <li><a href="index.html">Home</a></li>
-          <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
+          <li class="nav-account d-none"><a href="account.html">Account</a></li>
           <li><a href="support.html">Support</a></li>
-          <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
+          <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
         </ul>
         <div class="nav-buttons">
           <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
           <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-          <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
+          <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
         </div>
         <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
           <i data-feather="menu"></i>

--- a/index.html
+++ b/index.html
@@ -29,14 +29,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html" aria-current="page">Home</a></li>
-                    <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>

--- a/logout.html
+++ b/logout.html
@@ -22,14 +22,14 @@
         </a>
         <ul class="nav-links" id="nav-menu">
           <li><a href="index.html">Home</a></li>
-          <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
+          <li class="nav-account d-none"><a href="account.html">Account</a></li>
           <li><a href="support.html">Support</a></li>
-          <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
+          <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
         </ul>
         <div class="nav-buttons">
           <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
           <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-          <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
+          <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
         </div>
         <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
           <i data-feather="menu"></i>
@@ -68,6 +68,7 @@
       try {
         await window.supabaseClient.auth.signOut();
       } catch (e) {}
+      localStorage.setItem('ps_logged_in','false');
       window.location.href = '/auth.html';
     })();
   </script>

--- a/onboarding.html
+++ b/onboarding.html
@@ -22,14 +22,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html">Home</a></li>
-                    <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>

--- a/pricing.html
+++ b/pricing.html
@@ -22,14 +22,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html">Home</a></li>
-                    <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html">Support</a></li>
-                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                     <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>

--- a/support.html
+++ b/support.html
@@ -22,14 +22,14 @@
                 </a>
                 <ul class="nav-links" id="nav-menu">
                     <li><a href="index.html">Home</a></li>
-                    <li class="nav-account d-none" hidden><a href="account.html">Account</a></li>
+                    <li class="nav-account d-none"><a href="account.html">Account</a></li>
                     <li><a href="support.html" aria-current="page">Support</a></li>
-                    <li class="nav-open-app d-none" hidden><a href="https://chat.prosperspot.com">Open App</a></li>
+                    <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
                     <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
-                    <a href="logout.html" class="btn btn-secondary nav-logout d-none" hidden>Logout</a>
+                    <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
                     <i data-feather="menu"></i>


### PR DESCRIPTION
## Summary
- remove hidden attribute from nav items and keep consistent `d-none` default
- remember last auth state so nav shows correct links before Supabase loads
- reset stored auth flag on logout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0ed3238548326805ed15097ea5fd0