### PR TITLE
Add translucent background for hero text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -46,6 +46,12 @@ nav { display: flex; justify-content: space-between; align-items: center; }
 /* --- Hero Section --- */
 .hero { text-align: center; padding: 140px 0; min-height: 80vh; display: flex; align-items: center; justify-content: center; }
 .hero-content { max-width: 800px; margin: 0 auto; }
+.hero-text-box {
+    background: rgba(19, 18, 44, 0.8);
+    padding: 40px;
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
 .hero h1 { font-size: 3.5rem; line-height: 1.1; margin-bottom: 30px; color: var(--heading-color); background: linear-gradient(90deg, #ffffff, #dcdce6); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
 .hero-tagline { font-size: 1.5rem; color: var(--heading-color); margin-bottom: 30px; }
 .hero p { font-size: 1.25rem; color: var(--secondary-color); margin-bottom: 30px; max-width: 650px; margin-left: auto; margin-right: auto; }

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <!-- Hero Section -->
         <section class="hero">
             <div class="container">
-                <div class="hero-content">
+                <div class="hero-content hero-text-box">
                     <h1 class="animate-on-scroll invert-text">Smarter AI. Built for Real Work.</h1>
                     <p class="hero-tagline animate-on-scroll">Your Affordable AI Co‑Pilot for Study, Research, and Everything in Between</p>
                     <p class="animate-on-scroll">Prosper Spot gives you serious AI power — without the bloated price tag.</p>


### PR DESCRIPTION
## Summary
- highlight hero copy with new semi-transparent card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1befe2ed48326adc28b6787db4c84