### PR TITLE
feat: add waitlist product gating overlay

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -246,3 +246,46 @@ footer { padding: 80px 0 30px; border-top: 1px solid var(--border-color); }
     color: #fff;
     text-decoration: underline;
 }
+
+/* product-gate */
+body.gated [data-gated] { position: relative; }
+body.gated [data-gated].gate-active > :not(.gate-overlay) { pointer-events: none; }
+body.gated .gate-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(30, 41, 59, 0.65);
+    backdrop-filter: blur(4px) brightness(0.9);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    z-index: 10;
+}
+body.gated .gate-overlay .gate-banner {
+    position: absolute;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(255, 255, 255, 0.9);
+    color: #1f2937;
+    padding: 4px 12px;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+body.gated .gate-overlay .gate-cta {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: center;
+}
+body.gated .gate-overlay .gate-headline {
+    font-weight: 600;
+    color: var(--heading-color);
+}
+body.gated .gate-overlay .gate-btn:hover,
+body.gated .gate-overlay .gate-btn:focus {
+    transform: scale(1.02);
+    box-shadow: 0 0 15px rgba(138, 43, 226, 0.6), 0 0 30px rgba(74, 144, 226, 0.4);
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -137,6 +137,65 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    // Product gating overlay
+    function initProductGates() {
+        if (!document.body.classList.contains('gated')) return;
+        const cards = document.querySelectorAll('[data-gated]');
+        cards.forEach(card => {
+            if (card.dataset.gateInit === 'true') return;
+            card.dataset.gateInit = 'true';
+            card.classList.add('gate-active');
+            if (getComputedStyle(card).position === 'static') {
+                card.style.position = 'relative';
+            }
+            // remove focus from underlying interactive elements
+            card.querySelectorAll('a, button, input, textarea, select').forEach(el => {
+                if (!el.closest('.gate-overlay')) {
+                    el.setAttribute('tabindex', '-1');
+                }
+            });
+            const overlay = document.createElement('div');
+            overlay.className = 'gate-overlay';
+            overlay.setAttribute('role', 'region');
+            overlay.setAttribute('aria-label', 'Invite-only gate');
+
+            const banner = document.createElement('div');
+            banner.className = 'gate-banner';
+            banner.textContent = 'Coming soon — invite only';
+            overlay.appendChild(banner);
+
+            const cta = document.createElement('div');
+            cta.className = 'gate-cta';
+
+            const headline = document.createElement('p');
+            headline.className = 'gate-headline';
+            headline.textContent = 'Access by invitation.';
+            cta.appendChild(headline);
+
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn btn-primary gate-btn';
+            const plan = card.dataset.plan || '';
+            if (plan) btn.dataset.plan = plan;
+            btn.textContent = 'Join the waitlist';
+            btn.addEventListener('click', () => {
+                window.dataLayer?.push({
+                    event: 'waitlist_click',
+                    plan,
+                    location_path: window.location.pathname,
+                    ref: document.referrer || ''
+                });
+                window.location.href = '/waitlist';
+            });
+            cta.appendChild(btn);
+
+            overlay.appendChild(cta);
+            card.appendChild(overlay);
+        });
+    }
+
+    initProductGates();
+
     // On-Scroll Animations
     const observer = new IntersectionObserver((entries) => {
         entries.forEach(entry => {

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         crossorigin="anonymous">
     </script>
 </head>
-<body>
+<body class="gated">
 
     <div class="background-glow"></div>
 
@@ -98,7 +98,7 @@
                     <p class="animate-on-scroll">No confusing tiers. No token meters. Just access.</p>
                 </div>
                 <div class="pricing-grid">
-                    <div class="pricing-card animate-on-scroll">
+                    <div class="pricing-card animate-on-scroll" data-gated="true" data-plan="student">
                         <h3>Student</h3>
                         <p class="price-desc">For learners and classrooms</p>
                         <div class="price"><sup>$</sup>5<span>/mo</span></div>
@@ -108,7 +108,7 @@
                         </ul>
                         <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="student">Start 14-Day Free Trial →</a>
                     </div>
-                    <div class="pricing-card popular animate-on-scroll">
+                    <div class="pricing-card popular animate-on-scroll" data-gated="true" data-plan="standard">
                         <div class="popular-badge">Most Popular</div>
                         <h3>Standard</h3>
                         <p class="price-desc">For reliable everyday AI</p>
@@ -120,7 +120,7 @@
                         </ul>
                         <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="standard">Start 14-Day Free Trial →</a>
                     </div>
-                    <div class="pricing-card animate-on-scroll">
+                    <div class="pricing-card animate-on-scroll" data-gated="true" data-plan="pro">
                         <h3>Pro</h3>
                         <p class="price-desc">For builders and power users</p>
                         <div class="price"><sup>$</sup>20<span>/mo</span></div>

--- a/pricing.html
+++ b/pricing.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://unpkg.com/feather-icons" crossorigin="anonymous"></script>
 </head>
-<body>
+<body class="gated">
     <div class="background-glow"></div>
     <header>
         <div class="container">
@@ -46,7 +46,7 @@
                     <p class="trial-note">Start 14-Day Free Trial. Cancel anytime before day 14.</p>
                 </div>
                 <div class="pricing-grid">
-                    <div class="pricing-card">
+                    <div class="pricing-card" data-gated="true" data-plan="student">
                         <h3>Student</h3>
                         <p class="price-desc">For learners and classrooms</p>
                         <div class="price"><sup>$</sup>5<span>/mo</span></div>
@@ -56,7 +56,7 @@
                         </ul>
                         <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="student">Start 14-Day Free Trial →</a>
                     </div>
-                    <div class="pricing-card popular">
+                    <div class="pricing-card popular" data-gated="true" data-plan="standard">
                         <div class="popular-badge">Most Popular</div>
                         <h3>Standard</h3>
                         <p class="price-desc">For reliable everyday AI</p>
@@ -68,7 +68,7 @@
                         </ul>
                         <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="standard">Start 14-Day Free Trial →</a>
                     </div>
-                    <div class="pricing-card">
+                    <div class="pricing-card" data-gated="true" data-plan="pro">
                         <h3>Pro</h3>
                         <p class="price-desc">For builders and power users</p>
                         <div class="price"><sup>$</sup>20<span>/mo</span></div>


### PR DESCRIPTION
## Summary
- gate pricing cards behind an invite-only overlay driven by a `gated` body class and `data-gated` markers
- add waitlist CTA overlay with analytics hook and plan-aware button
- style semi-transparent overlay banner and CTA to match site aesthetic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f416e8ac832695d854287c3af7ce