### PR TITLE
Add Lemon Squeezy buy buttons

### DIFF
--- a/account.html
+++ b/account.html
@@ -28,7 +28,7 @@
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
                     <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -72,6 +72,7 @@
     <script src="assets/js/version.js"></script>
     <script src="assets/js/script.js"></script>
     <script src="assets/js/account.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>feather.replace();</script>
 </body>
 </html>

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,5 +1,5 @@
 window.checkoutLinks = {
-  student: 'https://prosperspot.lemonsqueezy.com/checkout/buy/606476',
-  standard: 'https://prosperspot.lemonsqueezy.com/checkout/buy/606477',
-  pro: 'https://prosperspot.lemonsqueezy.com/checkout/buy/606478'
+  student: 'https://prosperspotus.lemonsqueezy.com/buy/aa2befc2-ac07-4da0-a601-34cf1e5bff2e?embed=1&discount=0',
+  standard: 'https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0',
+  pro: 'https://prosperspotus.lemonsqueezy.com/buy/0cc965b1-0ae3-4ef2-86d0-6e99e305888a?embed=1&discount=0'
 };

--- a/auth.html
+++ b/auth.html
@@ -28,7 +28,7 @@
         </ul>
         <div class="nav-buttons">
           <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-          <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+          <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
           <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
         </div>
         <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -81,6 +81,7 @@
   <script src="assets/js/checkout.js"></script>
   <script src="assets/js/script.js"></script>
   <script src="assets/js/auth.js"></script>
+  <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
   <script>feather.replace();</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
                     <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -106,7 +106,7 @@
                             <li><i data-feather="check-circle"></i> Faster answers</li>
                             <li><i data-feather="check-circle"></i> Larger context</li>
                         </ul>
-                        <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="student">Start 14-Day Free Trial →</a>
+                        <a href="https://prosperspotus.lemonsqueezy.com/buy/aa2befc2-ac07-4da0-a601-34cf1e5bff2e?embed=1&discount=0" class="lemonsqueezy-button">Buy Student</a>
                     </div>
                     <div class="pricing-card popular animate-on-scroll" data-plan="standard">
                         <div class="popular-badge">Most Popular</div>
@@ -118,7 +118,7 @@
                             <li><i data-feather="check-circle"></i> Larger context</li>
                             <li><i data-feather="check-circle"></i> Priority queue</li>
                         </ul>
-                        <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="standard">Start 14-Day Free Trial →</a>
+                        <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
                     </div>
                     <div class="pricing-card animate-on-scroll" data-plan="pro">
                         <h3>Pro</h3>
@@ -130,7 +130,7 @@
                             <li><i data-feather="check-circle"></i> Priority queue</li>
                             <li><i data-feather="check-circle"></i> Advanced tools</li>
                         </ul>
-                        <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="pro">Upgrade Now</a>
+                        <a href="https://prosperspotus.lemonsqueezy.com/buy/0cc965b1-0ae3-4ef2-86d0-6e99e305888a?embed=1&discount=0" class="lemonsqueezy-button">Buy Pro</a>
                     </div>
                 </div>
             </div>
@@ -194,6 +194,7 @@
     <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/checkout.js"></script>
     <script src="assets/js/script.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>
         feather.replace();
     </script>

--- a/logout.html
+++ b/logout.html
@@ -28,7 +28,7 @@
         </ul>
         <div class="nav-buttons">
           <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-          <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+          <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
           <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
         </div>
         <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -71,6 +71,7 @@
       window.location.href = '/auth.html';
     })();
   </script>
+  <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
   <script>feather.replace();</script>
 </body>
 </html>

--- a/onboarding.html
+++ b/onboarding.html
@@ -28,7 +28,7 @@
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
                     <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -43,7 +43,7 @@
                 <div class="hero-content">
                     <h1>Pick your study buddy, tools, and limits</h1>
                     <p>You're all set! Customize how you work with AI and get more when you upgrade.</p>
-                    <a href="/pricing.html" class="btn btn-primary btn-large nav-upgrade" data-plan="standard">Start 14-Day Free Trial →</a>
+                    <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
                 </div>
             </div>
         </section>
@@ -66,6 +66,7 @@
     <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/checkout.js"></script>
     <script src="assets/js/script.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>feather.replace();</script>
 </body>
 </html>

--- a/pricing.html
+++ b/pricing.html
@@ -28,7 +28,7 @@
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
                     <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                     <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -54,7 +54,7 @@
                             <li><i data-feather="check-circle"></i> Faster answers</li>
                             <li><i data-feather="check-circle"></i> Larger context</li>
                         </ul>
-                        <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="student">Start 14-Day Free Trial →</a>
+                        <a href="https://prosperspotus.lemonsqueezy.com/buy/aa2befc2-ac07-4da0-a601-34cf1e5bff2e?embed=1&discount=0" class="lemonsqueezy-button">Buy Student</a>
                     </div>
                     <div class="pricing-card popular" data-plan="standard">
                         <div class="popular-badge">Most Popular</div>
@@ -66,7 +66,7 @@
                             <li><i data-feather="check-circle"></i> Larger context</li>
                             <li><i data-feather="check-circle"></i> Priority queue</li>
                         </ul>
-                        <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="standard">Start 14-Day Free Trial →</a>
+                          <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
                     </div>
                     <div class="pricing-card" data-plan="pro">
                         <h3>Pro</h3>
@@ -78,7 +78,7 @@
                             <li><i data-feather="check-circle"></i> Priority queue</li>
                             <li><i data-feather="check-circle"></i> Advanced tools</li>
                         </ul>
-                        <a href="/pricing.html" class="btn btn-primary nav-upgrade" data-plan="pro">Upgrade Now</a>
+                        <a href="https://prosperspotus.lemonsqueezy.com/buy/0cc965b1-0ae3-4ef2-86d0-6e99e305888a?embed=1&discount=0" class="lemonsqueezy-button">Buy Pro</a>
                     </div>
                 </div>
             </div>
@@ -102,6 +102,7 @@
     <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/checkout.js"></script>
     <script src="assets/js/script.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>feather.replace();</script>
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -28,7 +28,7 @@
                 </ul>
                 <div class="nav-buttons">
                     <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <a href="https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0" class="lemonsqueezy-button">Buy Standard</a>
                     <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -116,6 +116,7 @@
     <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/checkout.js"></script>
     <script src="assets/js/script.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>
         feather.replace();
     </script>


### PR DESCRIPTION
## Summary
- replace pricing and navigation links with Lemon Squeezy buy buttons for Student, Standard and Pro plans
- load Lemon Squeezy script on every page to enable the embed buttons
- update checkout helper with new plan URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9b5c8bc8c832686a9c93293605ab2