### PR TITLE
Switch purchase links to new Lemon Squeezy embed URLs

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,5 +1,5 @@
 window.checkoutLinks = {
-  student: 'https://prosperspot.lemonsqueezy.com/checkout/buy/606476',
-  standard: 'https://prosperspot.lemonsqueezy.com/checkout/buy/606477',
-  pro: 'https://prosperspot.lemonsqueezy.com/checkout/buy/606478'
+  student: 'https://prosperspotus.lemonsqueezy.com/buy/aa2befc2-ac07-4da0-a601-34cf1e5bff2e?embed=1&discount=0',
+  standard: 'https://prosperspotus.lemonsqueezy.com/buy/1e344447-7932-4d60-bda9-803cba73f9f7?embed=1&discount=0',
+  pro: 'https://prosperspotus.lemonsqueezy.com/buy/0cc965b1-0ae3-4ef2-86d0-6e99e305888a?embed=1&discount=0'
 };

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -114,6 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const slug = link.getAttribute('data-plan');
         if (window.checkoutLinks?.[slug]) {
             link.href = window.checkoutLinks[slug];
+            link.classList.add('lemonsqueezy-button');
         }
     });
 

--- a/config.js
+++ b/config.js
@@ -2,9 +2,9 @@ module.exports = {
   planPrefix: 'plan:',
   planGroups: {
     // Map Lemon Squeezy variant IDs to OWUI group names
-      '606476': 'plan:student',
-      '606477': 'plan:standard',
-      '606478': 'plan:pro',
+      'aa2befc2-ac07-4da0-a601-34cf1e5bff2e': 'plan:student',
+      '1e344447-7932-4d60-bda9-803cba73f9f7': 'plan:standard',
+      '0cc965b1-0ae3-4ef2-86d0-6e99e305888a': 'plan:pro',
   },
   grantStatuses: ['active', 'on_trial'],
   owui: {

--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
     <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/checkout.js"></script>
     <script src="assets/js/script.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>
         feather.replace();
     </script>

--- a/onboarding.html
+++ b/onboarding.html
@@ -66,6 +66,7 @@
     <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/checkout.js"></script>
     <script src="assets/js/script.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>feather.replace();</script>
 </body>
 </html>

--- a/pricing.html
+++ b/pricing.html
@@ -102,6 +102,7 @@
     <script src="assets/js/supabaseClient.js"></script>
     <script src="assets/js/checkout.js"></script>
     <script src="assets/js/script.js"></script>
+    <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>feather.replace();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace old Lemon Squeezy checkout URLs with new embed links for Student, Standard, and Pro plans
- add Lemon Squeezy embed script and button class so plan buttons open modal
- map new Lemon Squeezy variant IDs to plan groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9b9bc42f4832689f9e7bdb0b68719