### PR TITLE
feat: add themed auth modals with signup links

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -198,6 +198,14 @@ footer { padding: 80px 0 30px; border-top: 1px solid var(--border-color); }
 .footer-col ul { list-style: none; }
 .footer-col li { margin-bottom: 10px; }
 .footer-col a:hover { color: var(--heading-color); }
+
+/* --- Auth Modals --- */
+.modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%; display: none; align-items: center; justify-content: center; background: rgba(0, 0, 0, 0.6); z-index: 2000; }
+.modal.active { display: flex; }
+.modal-content { width: 100%; max-width: 400px; position: relative; }
+.modal-close { position: absolute; top: 8px; right: 12px; background: none; border: none; color: var(--heading-color); font-size: 1.5rem; cursor: pointer; }
+.switch-auth { margin-top: 16px; font-size: 0.875rem; text-align: center; }
+.switch-auth a { color: var(--heading-color); text-decoration: underline; }
 .footer-bottom { display: flex; justify-content: space-between; align-items: center; padding-top: 30px; border-top: 1px solid var(--border-color); color: var(--secondary-color); font-size: 0.9rem; }
 
 /* --- Animations --- */

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -1,6 +1,8 @@
 const form = document.getElementById('login-form');
 const msgEl = document.getElementById('message');
 const magicBtn = document.getElementById('magic-link');
+const signupForm = document.getElementById('signup-form');
+const signupMsg = document.getElementById('signup-message');
 
 const params = new URLSearchParams(window.location.search);
 const redirectParam = params.get('redirect');
@@ -30,36 +32,55 @@ window.supabaseClient.auth.onAuthStateChange((event, session) => {
   }
 });
 
-form.addEventListener('submit', async (e) => {
-  e.preventDefault();
-  msgEl.textContent = '';
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    msgEl.textContent = '';
 
-  const email = document.getElementById('email').value;
-  const password = document.getElementById('password').value;
+    const email = document.getElementById('email').value;
+    const password = document.getElementById('password').value;
 
-  const { data, error } = await window.supabaseClient.auth.signInWithPassword({ email, password });
-  if (error) {
-    msgEl.textContent = error.message;
-    msgEl.className = 'text-danger';
-    return;
-  }
-});
-
-magicBtn.addEventListener('click', async () => {
-  msgEl.textContent = '';
-
-  const email = document.getElementById('email').value;
-
-  const redirectTo = `${window.location.origin}/auth.html${window.location.search}`;
-  const { error } = await window.supabaseClient.auth.signInWithOtp({
-    email,
-    options: { emailRedirectTo: redirectTo },
+    const { error } = await window.supabaseClient.auth.signInWithPassword({ email, password });
+    if (error) {
+      msgEl.textContent = error.message;
+      msgEl.className = 'text-danger';
+      return;
+    }
   });
+
+  magicBtn?.addEventListener('click', async () => {
+    msgEl.textContent = '';
+
+    const email = document.getElementById('email').value;
+
+    const redirectTo = `${window.location.origin}/auth.html${window.location.search}`;
+    const { error } = await window.supabaseClient.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: redirectTo },
+    });
+    if (error) {
+      msgEl.textContent = error.message;
+      msgEl.className = 'text-danger';
+    } else {
+      msgEl.textContent = 'Magic link sent! Check your email.';
+      msgEl.className = 'text-success';
+    }
+  });
+}
+
+signupForm?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  signupMsg.textContent = '';
+
+  const email = document.getElementById('signup-email').value;
+  const password = document.getElementById('signup-password').value;
+
+  const { error } = await window.supabaseClient.auth.signUp({ email, password });
   if (error) {
-    msgEl.textContent = error.message;
-    msgEl.className = 'text-danger';
+    signupMsg.textContent = error.message;
+    signupMsg.className = 'text-danger';
   } else {
-    msgEl.textContent = 'Magic link sent! Check your email.';
-    msgEl.className = 'text-success';
+    signupMsg.textContent = 'Check your email for a confirmation link.';
+    signupMsg.className = 'text-success';
   }
 });

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -14,22 +14,12 @@ if (localStorage.getItem('ps_logged_in') === 'true') {
     wasLoggedIn = true;
 }
 
-const setRedirect = () => {
-    if (loginLink) {
-        const current = window.location.pathname + window.location.search;
-        loginLink.href = `auth.html?redirect=${encodeURIComponent(current)}`;
-    }
-};
-
-setRedirect();
-
 function showLogoutBanner() {
     if (document.getElementById('session-expired')) return;
     const banner = document.createElement('div');
     banner.id = 'session-expired';
     banner.className = 'session-expired';
-    const redirect = window.location.pathname + window.location.search;
-    banner.innerHTML = `Logged out due to inactivity — <a href="auth.html?redirect=${encodeURIComponent(redirect)}">Log in again</a>`;
+    banner.innerHTML = `Logged out due to inactivity — <a href="index.html#login">Log in again</a>`;
     document.body.prepend(banner);
 }
 
@@ -51,12 +41,54 @@ function updateNav(session) {
         localStorage.setItem('ps_logged_in', 'false');
         if (wasLoggedIn) showLogoutBanner();
         wasLoggedIn = false;
-        setRedirect();
     }
 }
 
 
 document.addEventListener('DOMContentLoaded', () => {
+
+    // Auth modal handling
+    const loginModal = document.getElementById('login-modal');
+    const signupModal = document.getElementById('signup-modal');
+    const openLoginBtn = document.getElementById('open-login');
+    const openSignupBtn = document.getElementById('open-signup');
+    const showSignupLink = document.getElementById('show-signup');
+    const showLoginLink = document.getElementById('show-login');
+    const modalCloseButtons = document.querySelectorAll('[data-close]');
+
+    const openModal = (modal) => {
+        modal?.classList.add('active');
+        document.body.style.overflow = 'hidden';
+    };
+
+    const closeModal = (modal) => {
+        modal?.classList.remove('active');
+        document.body.style.overflow = '';
+    };
+
+    openLoginBtn?.addEventListener('click', () => openModal(loginModal));
+    openSignupBtn?.addEventListener('click', () => openModal(signupModal));
+    showSignupLink?.addEventListener('click', (e) => {
+        e.preventDefault();
+        closeModal(loginModal);
+        openModal(signupModal);
+    });
+    showLoginLink?.addEventListener('click', (e) => {
+        e.preventDefault();
+        closeModal(signupModal);
+        openModal(loginModal);
+    });
+    modalCloseButtons.forEach(btn => btn.addEventListener('click', () => {
+        closeModal(loginModal);
+        closeModal(signupModal);
+    }));
+    window.addEventListener('click', (e) => {
+        if (e.target === loginModal) closeModal(loginModal);
+        if (e.target === signupModal) closeModal(signupModal);
+    });
+
+    if (window.location.hash === '#login') openModal(loginModal);
+    if (window.location.hash === '#signup') openModal(signupModal);
 
     // Mobile Navigation Toggle with accessibility
     const menuToggle = document.getElementById('menu-toggle');
@@ -118,23 +150,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    const sanitizeRedirect = (url) => {
-        try {
-            const u = new URL(url, window.location.origin);
-            if (u.origin !== window.location.origin) return '/pricing.html';
-            if (!u.pathname.startsWith('/')) return '/pricing.html';
-            return u.pathname + u.search + u.hash;
-        } catch {
-            return '/pricing.html';
-        }
-    };
-
     upgradeLinks.forEach(link => {
         link.addEventListener('click', (e) => {
             if (!currentSession) {
                 e.preventDefault();
-                const dest = sanitizeRedirect(link.getAttribute('href') || '/pricing.html');
-                window.location.href = `auth.html?redirect=${encodeURIComponent(dest)}`;
+                openModal(loginModal);
             }
         });
     });

--- a/auth.html
+++ b/auth.html
@@ -27,8 +27,8 @@
           <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
         </ul>
         <div class="nav-buttons">
-          <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-          <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+          <a href="index.html#login" class="btn btn-secondary nav-login">Log In</a>
+          <a href="index.html#signup" class="btn btn-primary nav-register">Sign Up</a>
           <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
         </div>
         <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -57,7 +57,8 @@
               <button type="button" id="magic-link" class="btn btn-secondary">Send Magic Link</button>
             </div>
           </form>
-          <div id="message" class="form-response mt-3" style="text-align:center;"></div>
+            <div id="message" class="form-response mt-3" style="text-align:center;"></div>
+          <p class="switch-auth" style="text-align:center;">Don't have an account? <a href="index.html#signup">Sign up</a></p>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
                     <li class="nav-open-app d-none"><a href="https://chat.prosperspot.com">Open App</a></li>
                 </ul>
                 <div class="nav-buttons">
-                    <a href="auth.html" class="btn btn-secondary nav-login">Log In</a>
-                    <a href="pricing.html" class="btn btn-primary nav-upgrade">Upgrade</a>
+                    <button class="btn btn-secondary nav-login" id="open-login">Log In</button>
+                    <button class="btn btn-primary nav-register" id="open-signup">Sign Up</button>
                     <a href="logout.html" class="btn btn-secondary nav-logout d-none">Logout</a>
                 </div>
                 <button class="menu-toggle" id="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
@@ -188,15 +188,62 @@
             </div>
         </div>
     </footer>
+    <!-- Auth Modals -->
+    <div id="login-modal" class="modal">
+        <div class="modal-content support-card" style="max-width:400px;">
+            <button class="modal-close" data-close>&times;</button>
+            <h2 style="text-align:center;margin-bottom:24px;">Sign In</h2>
+            <form id="login-form">
+                <div class="field">
+                    <label for="email">Email address</label>
+                    <input type="email" id="email" autocomplete="email" required />
+                    <div class="error">Valid email required.</div>
+                </div>
+                <div class="field">
+                    <label for="password">Password (optional if using magic link)</label>
+                    <input type="password" id="password" autocomplete="current-password" />
+                </div>
+                <div class="field" style="display:flex;gap:12px;">
+                    <button type="submit" class="btn btn-primary">Login</button>
+                    <button type="button" id="magic-link" class="btn btn-secondary">Send Magic Link</button>
+                </div>
+            </form>
+            <p class="switch-auth">Don't have an account? <a href="#" id="show-signup">Sign up</a></p>
+            <div id="message" class="form-response mt-3" style="text-align:center;"></div>
+        </div>
+    </div>
+
+    <div id="signup-modal" class="modal">
+        <div class="modal-content support-card" style="max-width:400px;">
+            <button class="modal-close" data-close>&times;</button>
+            <h2 style="text-align:center;margin-bottom:24px;">Sign Up</h2>
+            <form id="signup-form">
+                <div class="field">
+                    <label for="signup-email">Email address</label>
+                    <input type="email" id="signup-email" autocomplete="email" required />
+                </div>
+                <div class="field">
+                    <label for="signup-password">Password</label>
+                    <input type="password" id="signup-password" autocomplete="new-password" required />
+                </div>
+                <div class="field">
+                    <button type="submit" class="btn btn-primary" style="width:100%;">Create Account</button>
+                </div>
+            </form>
+            <p class="switch-auth">Already have an account? <a href="#" id="show-login">Log in</a></p>
+            <div id="signup-message" class="form-response mt-3" style="text-align:center;"></div>
+        </div>
+    </div>
 
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="assets/js/supabaseEnv.js"></script>
     <script src="assets/js/supabaseClient.js"></script>
+    <script src="assets/js/auth.js"></script>
     <script src="assets/js/checkout.js"></script>
     <script src="assets/js/script.js"></script>
     <script src="https://assets.lemonsqueezy.com/lemon.js" defer></script>
     <script>
         feather.replace();
     </script>
-</body>
+    </body>
 </html>


### PR DESCRIPTION
## Summary
- add login and signup buttons on homepage with popup modals
- style new modals to match site theme and handle navigation/login redirects
- include sign up link on standalone auth page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1c1d7cd08326bb3acecbdc60e68c